### PR TITLE
fix: file-tree discovers child pages created via pages.create

### DIFF
--- a/src/tools/file-tree.ts
+++ b/src/tools/file-tree.ts
@@ -9,7 +9,7 @@
 import type { Client } from '@notionhq/client';
 import { DEFAULT_PAGE_SIZE } from '../constants.js';
 import { extractPageTitle, retrieveDatabaseMetadata, retrievePageMetadata } from '../helpers.js';
-import type { AnyBlock, FileTreeParams, TreeNode } from '../types.js';
+import type { AnyBlock, AnyPage, FileTreeParams, TreeNode } from '../types.js';
 
 /**
  * Recursively build a tree node for a single Notion page.
@@ -69,6 +69,25 @@ async function buildFileTreeNode(
 
     startCursor = response.next_cursor ?? undefined;
   } while (startCursor);
+
+  // Supplementary discovery: find child pages created via pages.create() that
+  // may not appear as child_page blocks in blocks.children.list(). A single
+  // search call (capped at 100) catches the common case without paginating
+  // through the entire workspace, which would timeout on large workspaces.
+  const seenIds = new Set(node.children.map((c) => c.id));
+  const searchResponse = await notion.search({
+    query: '',
+    filter: { property: 'object', value: 'page' },
+    page_size: 100,
+  });
+
+  for (const result of searchResponse.results) {
+    const resultPage = result as AnyPage;
+    if (resultPage.parent?.page_id === pageId && !seenIds.has(resultPage.id)) {
+      seenIds.add(resultPage.id);
+      node.children.push(await buildFileTreeNode(notion, resultPage.id, maxDepth, depth + 1));
+    }
+  }
 
   return node;
 }


### PR DESCRIPTION
## Summary

Supplements the block-children walker in `notion_file_tree` with a search-based discovery pass. After walking `blocks.children.list()`, the tool now queries `notion.search()` filtered for pages and checks `parent.page_id` client-side. Pages already found through block children are deduplicated by ID.

This catches pages created via `pages.create({ parent: { page_id } })` that don't appear as `child_page` blocks in the block children listing.

Closes #4

## Summary by Sourcery

Bug Fixes:
- Ensure the file tree includes pages whose parent is set via pages.create({ parent: { page_id } }) but are missing from blocks.children.list().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file tree to comprehensively discover all child pages in your Notion structure.
  * File tree now captures previously undetected child pages through an improved search mechanism.
  * Better visualization of nested page hierarchies with more complete child page enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->