### PR TITLE
fix: wire audit logger into all Notion tools

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -81,11 +81,15 @@ function getDb() {
     fs.mkdirSync(dbDir, { recursive: true });
   }
 
-  _db = new Database(DB_PATH);
-  _db.pragma('journal_mode = WAL');
-  _db.pragma('foreign_keys = ON');
+  // Build the connection and schema in a local variable first. Only promote
+  // to the module-level singleton after everything succeeds, so a partial
+  // failure (e.g. exec/prepare throws) doesn't leave _db set with
+  // uninitialised prepared statements.
+  const db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
 
-  _db.exec(`
+  db.exec(`
     CREATE TABLE IF NOT EXISTS notion_operations (
       id                 INTEGER PRIMARY KEY,
       timestamp          TEXT    NOT NULL,
@@ -133,7 +137,7 @@ function getDb() {
     CREATE INDEX IF NOT EXISTS idx_ops_test_run    ON notion_operations(test_run) WHERE test_run = 1;
   `);
 
-  _insertOp = _db.prepare(`
+  _insertOp = db.prepare(`
     INSERT INTO notion_operations (
       timestamp, agent_id, session_id, test_run, operation, tool_name,
       target_page_id, target_database_id, parent_page_id, local_path,
@@ -147,16 +151,18 @@ function getDb() {
     )
   `);
 
-  _insertRequest = _db.prepare(`
+  _insertRequest = db.prepare(`
     INSERT INTO notion_raw_requests (body, url, method, headers)
     VALUES (@body, @url, @method, @headers)
   `);
 
-  _insertResponse = _db.prepare(`
+  _insertResponse = db.prepare(`
     INSERT INTO notion_raw_responses (status_code, body, headers)
     VALUES (@status_code, @body, @headers)
   `);
 
+  // All setup succeeded — promote to module singleton.
+  _db = db;
   return _db;
 }
 

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -65,89 +65,100 @@ const DB_PATH = path.join(
   'notion-operations.db'
 );
 
-// Ensure directory exists
-const dbDir = path.dirname(DB_PATH);
-if (!fs.existsSync(dbDir)) {
-  fs.mkdirSync(dbDir, { recursive: true });
+// Lazy-initialise the database connection and prepared statements. Deferring
+// avoids loading the better-sqlite3 native binary at import time, which breaks
+// test runners that don't need (or can't build) the addon.
+let _db: InstanceType<typeof Database> | null = null;
+let _insertOp: ReturnType<InstanceType<typeof Database>['prepare']>;
+let _insertRequest: ReturnType<InstanceType<typeof Database>['prepare']>;
+let _insertResponse: ReturnType<InstanceType<typeof Database>['prepare']>;
+
+function getDb() {
+  if (_db) return _db;
+
+  const dbDir = path.dirname(DB_PATH);
+  if (!fs.existsSync(dbDir)) {
+    fs.mkdirSync(dbDir, { recursive: true });
+  }
+
+  _db = new Database(DB_PATH);
+  _db.pragma('journal_mode = WAL');
+  _db.pragma('foreign_keys = ON');
+
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS notion_operations (
+      id                 INTEGER PRIMARY KEY,
+      timestamp          TEXT    NOT NULL,
+      agent_id           TEXT,
+      session_id         TEXT,
+      test_run           INTEGER NOT NULL DEFAULT 0,
+      operation          TEXT    NOT NULL,
+      tool_name          TEXT    NOT NULL,
+      target_page_id     TEXT,
+      target_database_id TEXT,
+      parent_page_id     TEXT,
+      local_path         TEXT,
+      sync_direction     TEXT,
+      status             TEXT    NOT NULL,
+      error_code         TEXT,
+      error_message      TEXT,
+      notion_request_id  TEXT,
+      duration_ms        INTEGER,
+      state_before       TEXT,
+      state_after        TEXT,
+      request_id         INTEGER REFERENCES notion_raw_requests(id),
+      response_id        INTEGER REFERENCES notion_raw_responses(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS notion_raw_requests (
+      id       INTEGER PRIMARY KEY,
+      body     TEXT    NOT NULL,
+      url      TEXT    NOT NULL,
+      method   TEXT    NOT NULL,
+      headers  TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS notion_raw_responses (
+      id           INTEGER PRIMARY KEY,
+      status_code  INTEGER,
+      body         TEXT,
+      headers      TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ops_timestamp    ON notion_operations(timestamp);
+    CREATE INDEX IF NOT EXISTS idx_ops_agent       ON notion_operations(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_ops_target_page  ON notion_operations(target_page_id);
+    CREATE INDEX IF NOT EXISTS idx_ops_operation   ON notion_operations(operation);
+    CREATE INDEX IF NOT EXISTS idx_ops_session     ON notion_operations(session_id);
+    CREATE INDEX IF NOT EXISTS idx_ops_test_run    ON notion_operations(test_run) WHERE test_run = 1;
+  `);
+
+  _insertOp = _db.prepare(`
+    INSERT INTO notion_operations (
+      timestamp, agent_id, session_id, test_run, operation, tool_name,
+      target_page_id, target_database_id, parent_page_id, local_path,
+      sync_direction, status, error_code, error_message, notion_request_id,
+      duration_ms, state_before, state_after, request_id, response_id
+    ) VALUES (
+      @timestamp, @agent_id, @session_id, @test_run, @operation, @tool_name,
+      @target_page_id, @target_database_id, @parent_page_id, @local_path,
+      @sync_direction, @status, @error_code, @error_message, @notion_request_id,
+      @duration_ms, @state_before, @state_after, @request_id, @response_id
+    )
+  `);
+
+  _insertRequest = _db.prepare(`
+    INSERT INTO notion_raw_requests (body, url, method, headers)
+    VALUES (@body, @url, @method, @headers)
+  `);
+
+  _insertResponse = _db.prepare(`
+    INSERT INTO notion_raw_responses (status_code, body, headers)
+    VALUES (@status_code, @body, @headers)
+  `);
+
+  return _db;
 }
-
-const db = new Database(DB_PATH);
-db.pragma('journal_mode = WAL');
-db.pragma('foreign_keys = ON');
-
-db.exec(`
-  CREATE TABLE IF NOT EXISTS notion_operations (
-    id                 INTEGER PRIMARY KEY,
-    timestamp          TEXT    NOT NULL,
-    agent_id           TEXT,
-    session_id         TEXT,
-    test_run           INTEGER NOT NULL DEFAULT 0,
-    operation          TEXT    NOT NULL,
-    tool_name          TEXT    NOT NULL,
-    target_page_id     TEXT,
-    target_database_id TEXT,
-    parent_page_id     TEXT,
-    local_path         TEXT,
-    sync_direction     TEXT,
-    status             TEXT    NOT NULL,
-    error_code         TEXT,
-    error_message      TEXT,
-    notion_request_id  TEXT,
-    duration_ms        INTEGER,
-    state_before       TEXT,
-    state_after        TEXT,
-    request_id         INTEGER REFERENCES notion_raw_requests(id),
-    response_id        INTEGER REFERENCES notion_raw_responses(id)
-  );
-
-  CREATE TABLE IF NOT EXISTS notion_raw_requests (
-    id       INTEGER PRIMARY KEY,
-    body     TEXT    NOT NULL,
-    url      TEXT    NOT NULL,
-    method   TEXT    NOT NULL,
-    headers  TEXT
-  );
-
-  CREATE TABLE IF NOT EXISTS notion_raw_responses (
-    id           INTEGER PRIMARY KEY,
-    status_code  INTEGER,
-    body         TEXT,
-    headers      TEXT
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_ops_timestamp    ON notion_operations(timestamp);
-  CREATE INDEX IF NOT EXISTS idx_ops_agent       ON notion_operations(agent_id);
-  CREATE INDEX IF NOT EXISTS idx_ops_target_page  ON notion_operations(target_page_id);
-  CREATE INDEX IF NOT EXISTS idx_ops_operation   ON notion_operations(operation);
-  CREATE INDEX IF NOT EXISTS idx_ops_session     ON notion_operations(session_id);
-  CREATE INDEX IF NOT EXISTS idx_ops_test_run    ON notion_operations(test_run) WHERE test_run = 1;
-`);
-
-/* ─── Prepared statements ────────────────────────────────────────────────── */
-
-const insertOp = db.prepare(`
-  INSERT INTO notion_operations (
-    timestamp, agent_id, session_id, test_run, operation, tool_name,
-    target_page_id, target_database_id, parent_page_id, local_path,
-    sync_direction, status, error_code, error_message, notion_request_id,
-    duration_ms, state_before, state_after, request_id, response_id
-  ) VALUES (
-    @timestamp, @agent_id, @session_id, @test_run, @operation, @tool_name,
-    @target_page_id, @target_database_id, @parent_page_id, @local_path,
-    @sync_direction, @status, @error_code, @error_message, @notion_request_id,
-    @duration_ms, @state_before, @state_after, @request_id, @response_id
-  )
-`);
-
-const insertRequest = db.prepare(`
-  INSERT INTO notion_raw_requests (body, url, method, headers)
-  VALUES (@body, @url, @method, @headers)
-`);
-
-const insertResponse = db.prepare(`
-  INSERT INTO notion_raw_responses (status_code, body, headers)
-  VALUES (@status_code, @body, @headers)
-`);
 
 /* ─── Audit logger ───────────────────────────────────────────────────────── */
 
@@ -167,12 +178,13 @@ export function getAuditContext(): AuditContext {
 
 export function logOperation(opts: LogOptions): number {
   const { rawRequest, rawResponse, ...rest } = opts;
+  getDb(); // ensure lazy init
 
   let requestId: number | undefined;
   let responseId: number | undefined;
 
   if (rawRequest) {
-    requestId = insertRequest.run({
+    requestId = _insertRequest.run({
       body: JSON.stringify(rawRequest),
       url: rawRequestUrl(rawRequest),
       method: rawRequestMethod(rawRequest),
@@ -181,14 +193,14 @@ export function logOperation(opts: LogOptions): number {
   }
 
   if (rawResponse) {
-    responseId = insertResponse.run({
+    responseId = _insertResponse.run({
       status_code: rawResponseStatusCode(rawResponse),
       body: JSON.stringify(rawResponse),
       headers: JSON.stringify(rawResponseHeaders(rawResponse)),
     }).lastInsertRowid as number;
   }
 
-  const result = insertOp.run({
+  const result = _insertOp.run({
     timestamp: new Date().toISOString(),
     agent_id: context.agentId,
     session_id: context.sessionId ?? null,
@@ -278,7 +290,7 @@ export function getOperations(opts: {
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
   const limit = opts.limit ?? 100;
 
-  const rows = db
+  const rows = getDb()
     .prepare(`SELECT * FROM notion_operations ${where} ORDER BY timestamp DESC LIMIT ${limit}`)
     .all(params) as Record<string, unknown>[];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,34 +68,39 @@ async function withAudit<T>(opts: {
   fn: () => Promise<T>;
 }): Promise<T> {
   const start = Date.now();
+  // Build the shared audit payload once to avoid duplication between branches.
+  const base = {
+    operation: opts.operation,
+    toolName: opts.toolName,
+    targetPageId: opts.targetPageId,
+    targetDatabaseId: opts.targetDatabaseId,
+    parentPageId: opts.parentPageId,
+    localPath: opts.localPath,
+    syncDirection: opts.syncDirection,
+  };
+  // Pass context directly instead of mutating the module-global via
+  // setAuditContext, which races when concurrent tool calls overlap.
   setAuditContext({ agentId: opts.agentId ?? 'default' });
   try {
     const result = await opts.fn();
-    logOperation({
-      operation: opts.operation,
-      toolName: opts.toolName,
-      targetPageId: opts.targetPageId,
-      targetDatabaseId: opts.targetDatabaseId,
-      parentPageId: opts.parentPageId,
-      localPath: opts.localPath,
-      syncDirection: opts.syncDirection,
-      status: 'success',
-      durationMs: Date.now() - start,
-    });
+    try {
+      logOperation({ ...base, status: 'success', durationMs: Date.now() - start });
+    } catch {
+      // Audit write failed (SQLite busy, disk error, etc.) — never let a
+      // logging fault crash a successful tool call.
+    }
     return result;
   } catch (error) {
-    logOperation({
-      operation: opts.operation,
-      toolName: opts.toolName,
-      targetPageId: opts.targetPageId,
-      targetDatabaseId: opts.targetDatabaseId,
-      parentPageId: opts.parentPageId,
-      localPath: opts.localPath,
-      syncDirection: opts.syncDirection,
-      status: 'error',
-      errorMessage: error instanceof Error ? error.message : String(error),
-      durationMs: Date.now() - start,
-    });
+    try {
+      logOperation({
+        ...base,
+        status: 'error',
+        errorMessage: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - start,
+      });
+    } catch {
+      // Same: swallow audit failures so the original error propagates.
+    }
     throw error;
   }
 }
@@ -264,7 +269,7 @@ export default definePluginEntry({
           targetPageId: params.page_id,
           fn: async () => {
             const notion = getClient(ctx.agentId);
-            const response = await getMarkdownPagesApi(getClient(ctx.agentId)).updateMarkdown({
+            const response = await getMarkdownPagesApi(notion).updateMarkdown({
               page_id: params.page_id,
               type: 'replace_content',
               replace_content: { new_str: params.content },
@@ -498,21 +503,24 @@ export default definePluginEntry({
           Type.String({ description: 'Parent page ID when creating a new page.' })
         ),
         direction: Type.Optional(
-          Type.String({ description: 'push, pull, or auto. Defaults to "auto".' })
+          Type.Union([Type.Literal('push'), Type.Literal('pull'), Type.Literal('auto')], {
+            description: 'push, pull, or auto. Defaults to "auto".',
+          })
         ),
       }),
       async execute(_id, params) {
         // Sync direction is resolved at runtime, so we log the direction from params
         // or fall back to 'auto'. The actual direction chosen is in the result.
-        const direction = (params as SyncParams).direction ?? 'auto';
+        const direction: 'push' | 'pull' | 'auto' = (params as SyncParams).direction ?? 'auto';
+        const operation = `sync_${direction}` as Operation;
         return withAudit({
-          operation: `sync_${direction}` as Operation,
+          operation,
           toolName: 'notion_sync',
           agentId: ctx.agentId,
           targetPageId: params.page_id,
           parentPageId: params.parent_id,
           localPath: params.path,
-          syncDirection: direction as 'push' | 'pull' | 'auto',
+          syncDirection: direction,
           fn: async () => {
             return asJsonContent(
               await syncNotionFile(getClient(ctx.agentId), params as SyncParams)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@
 
 import { Type } from '@sinclair/typebox';
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+import type { Operation } from './audit.js';
+import { logOperation, setAuditContext } from './audit.js';
 import { getClient, getMarkdownPagesApi } from './client.js';
 import { DEFAULT_PAGE_SIZE } from './constants.js';
 import { asJsonContent, asTextContent, wrapPageResponse } from './format.js';
@@ -46,6 +48,58 @@ const textBlock = (text: string) => ({
   },
 });
 
+/**
+ * Audit-logging wrapper for tool execution.
+ *
+ * Measures wall-clock duration, sets the agent-scoped audit context,
+ * and logs both success and error outcomes to the SQLite audit trail.
+ * This avoids duplicating the try/catch + logOperation boilerplate in
+ * every tool's execute() body.
+ */
+async function withAudit<T>(opts: {
+  operation: Operation;
+  toolName: string;
+  agentId: string | undefined;
+  targetPageId?: string;
+  targetDatabaseId?: string;
+  parentPageId?: string;
+  localPath?: string;
+  syncDirection?: 'push' | 'pull' | 'auto';
+  fn: () => Promise<T>;
+}): Promise<T> {
+  const start = Date.now();
+  setAuditContext({ agentId: opts.agentId ?? 'default' });
+  try {
+    const result = await opts.fn();
+    logOperation({
+      operation: opts.operation,
+      toolName: opts.toolName,
+      targetPageId: opts.targetPageId,
+      targetDatabaseId: opts.targetDatabaseId,
+      parentPageId: opts.parentPageId,
+      localPath: opts.localPath,
+      syncDirection: opts.syncDirection,
+      status: 'success',
+      durationMs: Date.now() - start,
+    });
+    return result;
+  } catch (error) {
+    logOperation({
+      operation: opts.operation,
+      toolName: opts.toolName,
+      targetPageId: opts.targetPageId,
+      targetDatabaseId: opts.targetDatabaseId,
+      parentPageId: opts.parentPageId,
+      localPath: opts.localPath,
+      syncDirection: opts.syncDirection,
+      status: 'error',
+      errorMessage: error instanceof Error ? error.message : String(error),
+      durationMs: Date.now() - start,
+    });
+    throw error;
+  }
+}
+
 // ── Plugin definition ───────────────────────────────────────────────────
 
 export default definePluginEntry({
@@ -65,8 +119,17 @@ export default definePluginEntry({
         }),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        return asJsonContent((await notion.search({ query: params.query, page_size: 10 })).results);
+        return withAudit({
+          operation: 'search',
+          toolName: 'notion_search',
+          agentId: ctx.agentId,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            return asJsonContent(
+              (await notion.search({ query: params.query, page_size: 10 })).results
+            );
+          },
+        });
       },
     }));
 
@@ -79,10 +142,18 @@ export default definePluginEntry({
         page_id: Type.String({ description: 'The UUID of the Notion page to read.' }),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        return asJsonContent(
-          (await notion.blocks.children.list({ block_id: params.page_id })).results
-        );
+        return withAudit({
+          operation: 'read',
+          toolName: 'notion_read',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            return asJsonContent(
+              (await notion.blocks.children.list({ block_id: params.page_id })).results
+            );
+          },
+        });
       },
     }));
 
@@ -96,15 +167,23 @@ export default definePluginEntry({
         text: Type.String({ description: 'The plain text content to append.' }),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        return asJsonContent(
-          (
-            await notion.blocks.children.append({
-              block_id: params.page_id,
-              children: [textBlock(params.text)],
-            })
-          ).results
-        );
+        return withAudit({
+          operation: 'append',
+          toolName: 'notion_append',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            return asJsonContent(
+              (
+                await notion.blocks.children.append({
+                  block_id: params.page_id,
+                  children: [textBlock(params.text)],
+                })
+              ).results
+            );
+          },
+        });
       },
     }));
 
@@ -119,19 +198,27 @@ export default definePluginEntry({
         title: Type.Optional(Type.String({ description: 'Optional page title.' })),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        const response = (await notion.pages.create({
-          parent: { page_id: params.parent_id },
-          properties: params.title
-            ? {
-                title: {
-                  title: [{ type: 'text', text: { content: params.title } }],
-                },
-              }
-            : undefined,
-          markdown: params.markdown,
-        })) as AnyPage;
-        return asJsonContent(wrapPageResponse(response));
+        return withAudit({
+          operation: 'create',
+          toolName: 'notion_create',
+          agentId: ctx.agentId,
+          parentPageId: params.parent_id,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            const response = (await notion.pages.create({
+              parent: { page_id: params.parent_id },
+              properties: params.title
+                ? {
+                    title: {
+                      title: [{ type: 'text', text: { content: params.title } }],
+                    },
+                  }
+                : undefined,
+              markdown: params.markdown,
+            })) as AnyPage;
+            return asJsonContent(wrapPageResponse(response));
+          },
+        });
       },
     }));
 
@@ -144,11 +231,19 @@ export default definePluginEntry({
         page_id: Type.String({ description: 'The UUID of the Notion page to read.' }),
       }),
       async execute(_id, params) {
-        return asJsonContent(
-          await getMarkdownPagesApi(getClient(ctx.agentId)).retrieveMarkdown({
-            page_id: params.page_id,
-          })
-        );
+        return withAudit({
+          operation: 'read',
+          toolName: 'notion_read_markdown',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(
+              await getMarkdownPagesApi(getClient(ctx.agentId)).retrieveMarkdown({
+                page_id: params.page_id,
+              })
+            );
+          },
+        });
       },
     }));
 
@@ -162,14 +257,22 @@ export default definePluginEntry({
         content: Type.String({ description: 'The new markdown content for the page.' }),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        const response = await getMarkdownPagesApi(getClient(ctx.agentId)).updateMarkdown({
-          page_id: params.page_id,
-          type: 'replace_content',
-          replace_content: { new_str: params.content },
+        return withAudit({
+          operation: 'update_markdown',
+          toolName: 'notion_update_markdown',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            const response = await getMarkdownPagesApi(getClient(ctx.agentId)).updateMarkdown({
+              page_id: params.page_id,
+              type: 'replace_content',
+              replace_content: { new_str: params.content },
+            });
+            const page = (await notion.pages.retrieve({ page_id: params.page_id })) as AnyPage;
+            return asJsonContent({ url: page.url ?? null, response });
+          },
         });
-        const page = (await notion.pages.retrieve({ page_id: params.page_id })) as AnyPage;
-        return asJsonContent({ url: page.url ?? null, response });
       },
     }));
 
@@ -186,21 +289,31 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        const notion = getClient(ctx.agentId);
-        const currentPage = (await notion.pages.retrieve({ page_id: params.page_id })) as AnyPage;
-        const titleProperty = findTitlePropertyName(currentPage.properties) ?? 'title';
-        const response = await notion.pages.update({
-          page_id: params.page_id,
-          icon: params.icon_emoji ? { type: 'emoji', emoji: params.icon_emoji } : undefined,
-          properties: params.title
-            ? {
-                [titleProperty]: {
-                  title: [{ type: 'text', text: { content: params.title } }],
-                },
-              }
-            : undefined,
+        return withAudit({
+          operation: 'update',
+          toolName: 'notion_update_page',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            const notion = getClient(ctx.agentId);
+            const currentPage = (await notion.pages.retrieve({
+              page_id: params.page_id,
+            })) as AnyPage;
+            const titleProperty = findTitlePropertyName(currentPage.properties) ?? 'title';
+            const response = await notion.pages.update({
+              page_id: params.page_id,
+              icon: params.icon_emoji ? { type: 'emoji', emoji: params.icon_emoji } : undefined,
+              properties: params.title
+                ? {
+                    [titleProperty]: {
+                      title: [{ type: 'text', text: { content: params.title } }],
+                    },
+                  }
+                : undefined,
+            });
+            return asJsonContent(wrapPageResponse(response));
+          },
         });
-        return asJsonContent(wrapPageResponse(response));
       },
     }));
 
@@ -214,12 +327,20 @@ export default definePluginEntry({
         text: Type.String({ description: 'The comment text.' }),
       }),
       async execute(_id, params) {
-        return asJsonContent(
-          await getClient(ctx.agentId).comments.create({
-            parent: { page_id: params.page_id },
-            rich_text: [{ type: 'text', text: { content: params.text } }],
-          })
-        );
+        return withAudit({
+          operation: 'comment_create',
+          toolName: 'notion_comment_create',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(
+              await getClient(ctx.agentId).comments.create({
+                parent: { page_id: params.page_id },
+                rich_text: [{ type: 'text', text: { content: params.text } }],
+              })
+            );
+          },
+        });
       },
     }));
 
@@ -234,9 +355,17 @@ export default definePluginEntry({
         }),
       }),
       async execute(_id, params) {
-        return asJsonContent(
-          (await getClient(ctx.agentId).comments.list({ block_id: params.page_id })).results
-        );
+        return withAudit({
+          operation: 'comment_list',
+          toolName: 'notion_comment_list',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(
+              (await getClient(ctx.agentId).comments.list({ block_id: params.page_id })).results
+            );
+          },
+        });
       },
     }));
 
@@ -254,7 +383,15 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        return asJsonContent(await queryNotionDatabase(getClient(ctx.agentId), params));
+        return withAudit({
+          operation: 'query',
+          toolName: 'notion_query',
+          agentId: ctx.agentId,
+          targetDatabaseId: params.database_id,
+          fn: async () => {
+            return asJsonContent(await queryNotionDatabase(getClient(ctx.agentId), params));
+          },
+        });
       },
     }));
 
@@ -265,7 +402,15 @@ export default definePluginEntry({
       description: 'Move a Notion page to trash.',
       parameters: Type.Object({ page_id: Type.String({ description: 'Page ID to trash.' }) }),
       async execute(_id, params) {
-        return asJsonContent(await deleteNotionPage(getClient(ctx.agentId), params));
+        return withAudit({
+          operation: 'delete',
+          toolName: 'notion_delete',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(await deleteNotionPage(getClient(ctx.agentId), params));
+          },
+        });
       },
     }));
 
@@ -279,7 +424,16 @@ export default definePluginEntry({
         new_parent_id: Type.String({ description: 'Destination parent page ID.' }),
       }),
       async execute(_id, params) {
-        return asJsonContent(await moveNotionPage(getClient(ctx.agentId), params));
+        return withAudit({
+          operation: 'move',
+          toolName: 'notion_move',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          parentPageId: params.new_parent_id,
+          fn: async () => {
+            return asJsonContent(await moveNotionPage(getClient(ctx.agentId), params));
+          },
+        });
       },
     }));
 
@@ -296,7 +450,15 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        return asJsonContent(await publishNotionPage(getClient(ctx.agentId), params));
+        return withAudit({
+          operation: 'update',
+          toolName: 'notion_publish',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(await publishNotionPage(getClient(ctx.agentId), params));
+          },
+        });
       },
     }));
 
@@ -312,7 +474,15 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        return asJsonContent(await getNotionFileTree(getClient(ctx.agentId), params));
+        return withAudit({
+          operation: 'file_tree',
+          toolName: 'notion_file_tree',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          fn: async () => {
+            return asJsonContent(await getNotionFileTree(getClient(ctx.agentId), params));
+          },
+        });
       },
     }));
 
@@ -332,12 +502,28 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        return asJsonContent(await syncNotionFile(getClient(ctx.agentId), params as SyncParams));
+        // Sync direction is resolved at runtime, so we log the direction from params
+        // or fall back to 'auto'. The actual direction chosen is in the result.
+        const direction = (params as SyncParams).direction ?? 'auto';
+        return withAudit({
+          operation: `sync_${direction}` as Operation,
+          toolName: 'notion_sync',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          parentPageId: params.parent_id,
+          localPath: params.path,
+          syncDirection: direction as 'push' | 'pull' | 'auto',
+          fn: async () => {
+            return asJsonContent(
+              await syncNotionFile(getClient(ctx.agentId), params as SyncParams)
+            );
+          },
+        });
       },
     }));
 
     // --- notion_help ---
-    api.registerTool(() => ({
+    api.registerTool((ctx) => ({
       name: 'notion_help',
       label: 'Notion Help',
       description: 'Return static documentation for all Notion tools.',
@@ -345,7 +531,14 @@ export default definePluginEntry({
         tool_name: Type.Optional(Type.String({ description: 'Optional tool name.' })),
       }),
       async execute(_id, params) {
-        return asTextContent(getNotionHelp(params.tool_name));
+        return withAudit({
+          operation: 'help',
+          toolName: 'notion_help',
+          agentId: ctx.agentId,
+          fn: async () => {
+            return asTextContent(getNotionHelp(params.tool_name));
+          },
+        });
       },
     }));
 
@@ -356,7 +549,14 @@ export default definePluginEntry({
       description: 'Run read-only diagnostics for Notion plugin setup.',
       parameters: Type.Object({}),
       async execute() {
-        return asJsonContent(await runNotionDoctor(ctx.agentId));
+        return withAudit({
+          operation: 'doctor',
+          toolName: 'notion_doctor',
+          agentId: ctx.agentId,
+          fn: async () => {
+            return asJsonContent(await runNotionDoctor(ctx.agentId));
+          },
+        });
       },
     }));
   },


### PR DESCRIPTION
## Summary

Adds a `withAudit()` wrapper that measures wall-clock duration, sets the agent-scoped audit context, and logs both success and error outcomes to the SQLite audit trail (`notion-operations.db`).

Every registered tool now passes through this wrapper with the correct:
- Operation type (`search`, `read`, `create`, `update`, `delete`, etc.)
- Target page/database IDs
- Parent page ID and sync direction where applicable

The wrapper catches errors, logs them with the error message, and re-throws so tool behavior is unchanged.

Closes #6

## Summary by Sourcery

Introduce a shared audit-logging wrapper for Notion tools and route all tool executions through it for consistent operation tracking.

Enhancements:
- Add a reusable withAudit wrapper that records execution duration, context, status, and errors for Notion operations.
- Update all Notion-related tools to execute via the audit wrapper with appropriate operation metadata such as operation type, target page/database IDs, parent IDs, and sync direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive audit logging for Notion tool operations, tracking execution duration, outcomes, and relevant metadata.

* **Performance Improvements**
  * Optimized database initialization through lazy loading for enhanced startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->