### PR TITLE
feat: add notion_logs_read tool for audit log inspection

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -13,6 +13,13 @@ import Database from 'better-sqlite3';
 
 /* ─── Types ──────────────────────────────────────────────────────────────── */
 
+/**
+ * The set of Notion operations the audit log can record.
+ *
+ * Each literal corresponds to a distinct tool-level action (e.g. `'read'` for
+ * page reads, `'sync_push'` for local→Notion syncs) so logs can be filtered
+ * by operation type.
+ */
 export type Operation =
   | 'search'
   | 'read'
@@ -33,9 +40,18 @@ export type Operation =
   | 'help'
   | 'doctor';
 
+/**
+ * Caller-supplied context attached to every audit log entry.
+ *
+ * Set once at startup via {@link setAuditContext} so individual
+ * {@link logOperation} calls don't need to repeat the agent/session info.
+ */
 export interface AuditContext {
+  /** Unique identifier for the agent instance writing logs. */
   agentId: string;
+  /** Optional MCP session ID, used to correlate entries within one session. */
   sessionId?: string;
+  /** When `true`, marks log rows as test data so they can be filtered out. */
   testRun?: boolean;
 }
 
@@ -174,14 +190,22 @@ let context: AuditContext = {
   testRun: false,
 };
 
+/** Replace the current audit context (agent ID, session, test flag). */
 export function setAuditContext(ctx: AuditContext) {
   context = { ...ctx };
 }
 
+/** Return a shallow copy of the current audit context. */
 export function getAuditContext(): AuditContext {
   return { ...context };
 }
 
+/**
+ * Write a single operation to the audit log and return its row ID.
+ *
+ * Optionally persists the raw HTTP request/response in separate tables and
+ * links them via foreign keys so large payloads don't bloat the main table.
+ */
 export function logOperation(opts: LogOptions): number {
   const { rawRequest, rawResponse, ...rest } = opts;
   getDb(); // ensure lazy init
@@ -233,6 +257,10 @@ export function logOperation(opts: LogOptions): number {
 }
 
 /* ─── Helpers to extract raw data from Notion SDK request/response objects ── */
+// The Notion SDK doesn't export concrete types for its internal request/response
+// objects, so we accept `object` and use `as` casts to reach the properties we
+// need. Each helper isolates a single field access so the cast is narrow and
+// easy to update if the SDK ever adds proper typings.
 
 function rawRequestUrl(req: object): string {
   return String((req as { url?: string }).url ?? '');
@@ -420,6 +448,12 @@ export function readAuditLogs(opts: {
   return db.prepare(sql).all(params) as Record<string, unknown>[];
 }
 
+/**
+ * Query the audit log with basic filters (legacy helper).
+ *
+ * Predates the full-featured {@link readAuditLogs}; kept for internal callers
+ * that only need agent/operation/page/time filtering without raw payload JOINs.
+ */
 export function getOperations(opts: {
   agentId?: string;
   operation?: Operation;
@@ -465,6 +499,7 @@ export function getOperations(opts: {
   }));
 }
 
+/** Convenience wrapper: return all `'delete'` operations, optionally scoped to an agent and time range. */
 export function getDeletedPages(opts: { agentId?: string; since?: string }) {
   return getOperations({
     agentId: opts.agentId,

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -260,7 +260,57 @@ function rawResponseHeaders(res: object): Record<string, string> {
   return (res as { headers?: Record<string, string> }).headers ?? {};
 }
 
+/* ─── Safe JSON parsing ─────────────────────────────────────────────────── */
+
+/**
+ * Parse a JSON string without throwing on malformed data.
+ *
+ * Returns `null` when the value is nullish, non-string, or unparseable,
+ * so a single corrupt row can't break an entire audit log read.
+ */
+function safeJsonParse(value: unknown): unknown | null {
+  if (value == null) return null;
+  if (typeof value !== 'string') return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Redact sensitive fields (Authorization headers, tokens) from a parsed
+ * request body object so raw log reads don't leak credentials.
+ */
+function redactSensitiveFields(obj: unknown): unknown {
+  if (obj == null || typeof obj !== 'object') return obj;
+  const record = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(record)) {
+    if (key.toLowerCase().includes('authorization') || key.toLowerCase().includes('token')) {
+      result[key] = '[REDACTED]';
+    } else if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+      result[key] = redactSensitiveFields(val);
+    } else {
+      result[key] = val;
+    }
+  }
+  return result;
+}
+
 /* ─── Query helpers ──────────────────────────────────────────────────────── */
+
+/**
+ * Clamp a limit value to a safe non-negative integer in the range [0, 100].
+ *
+ * Rejects NaN, fractional, and negative values that could cause unexpected
+ * SQLite behaviour (e.g. `LIMIT -1` disables the cap entirely).
+ */
+function clampLimit(raw: number | undefined, fallback = 20): number {
+  const n = raw ?? fallback;
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return fallback;
+  return Math.max(0, Math.min(n, 100));
+}
 
 /**
  * Extended audit log reader supporting all filterable columns.
@@ -320,7 +370,8 @@ export function readAuditLogs(opts: {
   }
 
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
-  const limit = opts.limit ?? 20;
+  const limit = clampLimit(opts.limit);
+  params.limit = limit;
 
   // When include_raw is true, JOIN the raw request/response tables so the
   // caller can inspect full HTTP payloads for debugging.
@@ -339,20 +390,16 @@ export function readAuditLogs(opts: {
         LEFT JOIN notion_raw_responses res ON o.response_id = res.id
         ${where}
         ORDER BY o.timestamp DESC
-        LIMIT ${limit}`;
+        LIMIT @limit`;
     const rows = db.prepare(sql).all(params) as Record<string, unknown>[];
     return rows.map((row) => ({
       ...row,
-      state_before: row.state_before ? JSON.parse(row.state_before as string) : null,
-      state_after: row.state_after ? JSON.parse(row.state_after as string) : null,
-      raw_request_body: row.raw_request_body ? JSON.parse(row.raw_request_body as string) : null,
-      raw_request_headers: row.raw_request_headers
-        ? JSON.parse(row.raw_request_headers as string)
-        : null,
-      raw_response_body: row.raw_response_body ? JSON.parse(row.raw_response_body as string) : null,
-      raw_response_headers: row.raw_response_headers
-        ? JSON.parse(row.raw_response_headers as string)
-        : null,
+      state_before: safeJsonParse(row.state_before),
+      state_after: safeJsonParse(row.state_after),
+      raw_request_body: redactSensitiveFields(safeJsonParse(row.raw_request_body)),
+      raw_request_headers: safeJsonParse(row.raw_request_headers),
+      raw_response_body: safeJsonParse(row.raw_response_body),
+      raw_response_headers: safeJsonParse(row.raw_response_headers),
     }));
   }
 
@@ -366,7 +413,7 @@ export function readAuditLogs(opts: {
       FROM notion_operations o
       ${where}
       ORDER BY o.timestamp DESC
-      LIMIT ${limit}`;
+      LIMIT @limit`;
   return db.prepare(sql).all(params) as Record<string, unknown>[];
 }
 
@@ -410,8 +457,8 @@ export function getOperations(opts: {
 
   return rows.map((row) => ({
     ...row,
-    state_before: row.state_before ? JSON.parse(row.state_before as string) : null,
-    state_after: row.state_after ? JSON.parse(row.state_after as string) : null,
+    state_before: safeJsonParse(row.state_before),
+    state_after: safeJsonParse(row.state_after),
   }));
 }
 

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -268,7 +268,7 @@ function rawResponseHeaders(res: object): Record<string, string> {
  * Returns `null` when the value is nullish, non-string, or unparseable,
  * so a single corrupt row can't break an entire audit log read.
  */
-function safeJsonParse(value: unknown): unknown | null {
+export function safeJsonParse(value: unknown): unknown | null {
   if (value == null) return null;
   if (typeof value !== 'string') return null;
   try {
@@ -282,7 +282,7 @@ function safeJsonParse(value: unknown): unknown | null {
  * Redact sensitive fields (Authorization headers, tokens) from a parsed
  * request body object so raw log reads don't leak credentials.
  */
-function redactSensitiveFields(obj: unknown): unknown {
+export function redactSensitiveFields(obj: unknown): unknown {
   if (obj == null || typeof obj !== 'object') return obj;
   const record = obj as Record<string, unknown>;
   const result: Record<string, unknown> = {};
@@ -306,7 +306,7 @@ function redactSensitiveFields(obj: unknown): unknown {
  * Rejects NaN, fractional, and negative values that could cause unexpected
  * SQLite behaviour (e.g. `LIMIT -1` disables the cap entirely).
  */
-function clampLimit(raw: number | undefined, fallback = 20): number {
+export function clampLimit(raw: number | undefined, fallback = 20): number {
   const n = raw ?? fallback;
   if (!Number.isFinite(n) || !Number.isInteger(n)) return fallback;
   return Math.max(0, Math.min(n, 100));

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -262,6 +262,114 @@ function rawResponseHeaders(res: object): Record<string, string> {
 
 /* ─── Query helpers ──────────────────────────────────────────────────────── */
 
+/**
+ * Extended audit log reader supporting all filterable columns.
+ *
+ * Unlike {@link getOperations} (which predates the tool surface), this function
+ * covers every filter the `notion_logs_read` tool exposes, including tool_name,
+ * status, session_id, and target_database_id, and optionally JOINs the raw
+ * request/response tables so callers can inspect full HTTP payloads.
+ */
+export function readAuditLogs(opts: {
+  agentId?: string;
+  sessionId?: string;
+  operation?: string;
+  toolName?: string;
+  status?: 'success' | 'error';
+  targetPageId?: string;
+  targetDatabaseId?: string;
+  since?: string;
+  limit?: number;
+  includeRaw?: boolean;
+}) {
+  const db = getDb();
+  const conditions: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (opts.agentId) {
+    conditions.push('o.agent_id = @agentId');
+    params.agentId = opts.agentId;
+  }
+  if (opts.sessionId) {
+    conditions.push('o.session_id = @sessionId');
+    params.sessionId = opts.sessionId;
+  }
+  if (opts.operation) {
+    conditions.push('o.operation = @operation');
+    params.operation = opts.operation;
+  }
+  if (opts.toolName) {
+    conditions.push('o.tool_name = @toolName');
+    params.toolName = opts.toolName;
+  }
+  if (opts.status) {
+    conditions.push('o.status = @status');
+    params.status = opts.status;
+  }
+  if (opts.targetPageId) {
+    conditions.push('o.target_page_id = @targetPageId');
+    params.targetPageId = opts.targetPageId;
+  }
+  if (opts.targetDatabaseId) {
+    conditions.push('o.target_database_id = @targetDatabaseId');
+    params.targetDatabaseId = opts.targetDatabaseId;
+  }
+  if (opts.since) {
+    conditions.push('o.timestamp >= @since');
+    params.since = opts.since;
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = opts.limit ?? 20;
+
+  // When include_raw is true, JOIN the raw request/response tables so the
+  // caller can inspect full HTTP payloads for debugging.
+  if (opts.includeRaw) {
+    const sql = `
+      SELECT o.*,
+             req.url   AS raw_request_url,
+             req.method AS raw_request_method,
+             req.body   AS raw_request_body,
+             req.headers AS raw_request_headers,
+             res.status_code AS raw_response_status,
+             res.body   AS raw_response_body,
+             res.headers AS raw_response_headers
+        FROM notion_operations o
+        LEFT JOIN notion_raw_requests  req ON o.request_id  = req.id
+        LEFT JOIN notion_raw_responses res ON o.response_id = res.id
+        ${where}
+        ORDER BY o.timestamp DESC
+        LIMIT ${limit}`;
+    const rows = db.prepare(sql).all(params) as Record<string, unknown>[];
+    return rows.map((row) => ({
+      ...row,
+      state_before: row.state_before ? JSON.parse(row.state_before as string) : null,
+      state_after: row.state_after ? JSON.parse(row.state_after as string) : null,
+      raw_request_body: row.raw_request_body ? JSON.parse(row.raw_request_body as string) : null,
+      raw_request_headers: row.raw_request_headers
+        ? JSON.parse(row.raw_request_headers as string)
+        : null,
+      raw_response_body: row.raw_response_body ? JSON.parse(row.raw_response_body as string) : null,
+      raw_response_headers: row.raw_response_headers
+        ? JSON.parse(row.raw_response_headers as string)
+        : null,
+    }));
+  }
+
+  // Compact path: skip JOINs and omit state_before/state_after blobs to keep
+  // output concise. These columns are large and rarely needed in quick overviews.
+  const sql = `
+    SELECT o.id, o.timestamp, o.agent_id, o.session_id, o.test_run,
+           o.operation, o.tool_name, o.target_page_id, o.target_database_id,
+           o.parent_page_id, o.local_path, o.sync_direction, o.status,
+           o.error_code, o.error_message, o.notion_request_id, o.duration_ms
+      FROM notion_operations o
+      ${where}
+      ORDER BY o.timestamp DESC
+      LIMIT ${limit}`;
+  return db.prepare(sql).all(params) as Record<string, unknown>[];
+}
+
 export function getOperations(opts: {
   agentId?: string;
   operation?: Operation;

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -365,8 +365,11 @@ export function readAuditLogs(opts: {
     params.targetDatabaseId = opts.targetDatabaseId;
   }
   if (opts.since) {
+    // Normalize to canonical ISO-8601 with milliseconds so lexicographic
+    // comparison matches the toISOString() format stored in the DB.
+    const d = new Date(opts.since);
     conditions.push('o.timestamp >= @since');
-    params.since = opts.since;
+    params.since = Number.isNaN(d.getTime()) ? opts.since : d.toISOString();
   }
 
   const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -397,7 +400,7 @@ export function readAuditLogs(opts: {
       state_before: safeJsonParse(row.state_before),
       state_after: safeJsonParse(row.state_after),
       raw_request_body: redactSensitiveFields(safeJsonParse(row.raw_request_body)),
-      raw_request_headers: safeJsonParse(row.raw_request_headers),
+      raw_request_headers: redactSensitiveFields(safeJsonParse(row.raw_request_headers)),
       raw_response_body: safeJsonParse(row.raw_response_body),
       raw_response_headers: safeJsonParse(row.raw_response_headers),
     }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { findTitlePropertyName } from './helpers.js';
 import { runNotionDoctor } from './tools/doctor.js';
 import { getNotionFileTree } from './tools/file-tree.js';
 import { getNotionHelp } from './tools/help.js';
+import { readNotionLogs } from './tools/logs.js';
 import { deleteNotionPage, moveNotionPage, publishNotionPage } from './tools/pages.js';
 import { queryNotionDatabase } from './tools/query.js';
 import { syncNotionFile } from './tools/sync.js';
@@ -30,6 +31,7 @@ export { NOTION_VERSION } from './constants.js';
 export { runNotionDoctor } from './tools/doctor.js';
 export { getNotionFileTree } from './tools/file-tree.js';
 export { getNotionHelp } from './tools/help.js';
+export { readNotionLogs } from './tools/logs.js';
 export { deleteNotionPage, moveNotionPage, publishNotionPage } from './tools/pages.js';
 export { queryNotionDatabase } from './tools/query.js';
 export { syncNotionFile } from './tools/sync.js';
@@ -565,6 +567,49 @@ export default definePluginEntry({
             return asJsonContent(await runNotionDoctor(ctx.agentId));
           },
         });
+      },
+    }));
+
+    // --- notion_logs_read ---
+    api.registerTool(() => ({
+      name: 'notion_logs_read',
+      label: 'Notion Logs Read',
+      description:
+        'Read audit log entries from the local notion-operations.db. Supports filtering by tool, operation, status, page/database ID, agent, session, and time range.',
+      parameters: Type.Object({
+        limit: Type.Optional(
+          Type.Number({ description: 'Max entries to return (default 20, max 100).' })
+        ),
+        tool_name: Type.Optional(Type.String({ description: 'Filter by tool name.' })),
+        operation: Type.Optional(
+          Type.String({ description: 'Filter by operation type (search, read, create, etc.).' })
+        ),
+        status: Type.Optional(
+          Type.String({ description: 'Filter by status: "success" or "error".' })
+        ),
+        page_id: Type.Optional(Type.String({ description: 'Filter by target page ID.' })),
+        database_id: Type.Optional(Type.String({ description: 'Filter by target database ID.' })),
+        since: Type.Optional(
+          Type.String({ description: 'ISO timestamp lower bound for entries.' })
+        ),
+        session_id: Type.Optional(Type.String({ description: 'Filter by session ID.' })),
+        agent_id: Type.Optional(Type.String({ description: 'Filter by agent ID.' })),
+        include_raw: Type.Optional(
+          Type.Boolean({
+            description: 'Include raw HTTP request/response payloads (default false).',
+          })
+        ),
+      }),
+      async execute(_id, params) {
+        // Cap limit to prevent accidentally dumping the entire audit table.
+        const limit = Math.min(params.limit ?? 20, 100);
+        return asJsonContent(
+          readNotionLogs({
+            ...params,
+            limit,
+            status: params.status as 'success' | 'error' | undefined,
+          })
+        );
       },
     }));
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -585,7 +585,9 @@ export default definePluginEntry({
           Type.String({ description: 'Filter by operation type (search, read, create, etc.).' })
         ),
         status: Type.Optional(
-          Type.String({ description: 'Filter by status: "success" or "error".' })
+          Type.Union([Type.Literal('success'), Type.Literal('error')], {
+            description: 'Filter by status: "success" or "error".',
+          })
         ),
         page_id: Type.Optional(Type.String({ description: 'Filter by target page ID.' })),
         database_id: Type.Optional(Type.String({ description: 'Filter by target database ID.' })),
@@ -601,13 +603,9 @@ export default definePluginEntry({
         ),
       }),
       async execute(_id, params) {
-        // Cap limit to prevent accidentally dumping the entire audit table.
-        const limit = Math.min(params.limit ?? 20, 100);
         return asJsonContent(
           readNotionLogs({
             ...params,
-            limit,
-            status: params.status as 'success' | 'error' | undefined,
           })
         );
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,7 +571,7 @@ export default definePluginEntry({
     }));
 
     // --- notion_logs_read ---
-    api.registerTool(() => ({
+    api.registerTool((ctx) => ({
       name: 'notion_logs_read',
       label: 'Notion Logs Read',
       description:
@@ -606,6 +606,8 @@ export default definePluginEntry({
         return asJsonContent(
           readNotionLogs({
             ...params,
+            // Default to the calling agent's context unless explicitly overridden.
+            agent_id: params.agent_id ?? ctx.agentId,
           })
         );
       },

--- a/src/tools/help.ts
+++ b/src/tools/help.ts
@@ -125,6 +125,24 @@ export const TOOL_DOCS: ToolDoc[] = [
     parameters: [],
     example: '{}',
   },
+  {
+    name: 'notion_logs_read',
+    description:
+      'Read audit log entries from the local notion-operations.db with optional filters.',
+    parameters: [
+      'limit?: number (default 20, max 100)',
+      'tool_name?: string',
+      'operation?: string',
+      'status?: "success" | "error"',
+      'page_id?: string',
+      'database_id?: string',
+      'since?: ISO timestamp',
+      'session_id?: string',
+      'agent_id?: string',
+      'include_raw?: boolean (default false)',
+    ],
+    example: '{"operation":"create","status":"error","limit":10}',
+  },
 ];
 
 /**

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,0 +1,46 @@
+/**
+ * Read audit logs from the local SQLite database.
+ *
+ * Wraps {@link readAuditLogs} from the audit module, mapping the tool's
+ * snake_case parameter names to the camelCase options the query function expects.
+ *
+ * @module
+ */
+
+import { readAuditLogs } from '../audit.js';
+
+export interface ReadNotionLogsParams {
+  limit?: number;
+  tool_name?: string;
+  operation?: string;
+  status?: 'success' | 'error';
+  page_id?: string;
+  database_id?: string;
+  since?: string;
+  session_id?: string;
+  agent_id?: string;
+  include_raw?: boolean;
+}
+
+/**
+ * Query the notion-operations.db audit log with the given filters.
+ *
+ * Returns an object with `count` and `rows` so the caller always knows
+ * how many results came back without counting array elements.
+ */
+export function readNotionLogs(params: ReadNotionLogsParams) {
+  const rows = readAuditLogs({
+    agentId: params.agent_id,
+    sessionId: params.session_id,
+    operation: params.operation,
+    toolName: params.tool_name,
+    status: params.status,
+    targetPageId: params.page_id,
+    targetDatabaseId: params.database_id,
+    since: params.since,
+    limit: params.limit,
+    includeRaw: params.include_raw,
+  });
+
+  return { count: rows.length, rows };
+}

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -9,6 +9,10 @@
 
 import { readAuditLogs } from '../audit.js';
 
+/** Max rows the tool will ever return. */
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 20;
+
 export interface ReadNotionLogsParams {
   limit?: number;
   tool_name?: string;
@@ -25,10 +29,21 @@ export interface ReadNotionLogsParams {
 /**
  * Query the notion-operations.db audit log with the given filters.
  *
+ * Clamps `limit` to a safe non-negative integer (max 100) so callers
+ * outside the tool schema can't accidentally request unbounded reads.
  * Returns an object with `count` and `rows` so the caller always knows
  * how many results came back without counting array elements.
  */
 export function readNotionLogs(params: ReadNotionLogsParams) {
+  const rawLimit = params.limit ?? DEFAULT_LIMIT;
+  const limit = Math.max(
+    0,
+    Math.min(
+      Number.isFinite(rawLimit) && Number.isInteger(rawLimit) ? rawLimit : DEFAULT_LIMIT,
+      MAX_LIMIT
+    )
+  );
+
   const rows = readAuditLogs({
     agentId: params.agent_id,
     sessionId: params.session_id,
@@ -38,7 +53,7 @@ export function readNotionLogs(params: ReadNotionLogsParams) {
     targetPageId: params.page_id,
     targetDatabaseId: params.database_id,
     since: params.since,
-    limit: params.limit,
+    limit,
     includeRaw: params.include_raw,
   });
 

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -7,22 +7,40 @@
  * @module
  */
 
+// ESM requires explicit file extensions in import specifiers. TypeScript compiles
+// .ts → .js, so we reference the compiled output extension here.
 import { readAuditLogs } from '../audit.js';
 
 /** Max rows the tool will ever return. */
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
 
+/**
+ * Parameters accepted by {@link readNotionLogs}.
+ *
+ * Field names use snake_case to match the MCP tool schema exposed to callers;
+ * the function maps them to the camelCase options the audit module expects.
+ */
 export interface ReadNotionLogsParams {
+  /** Maximum number of rows to return (clamped to {@link MAX_LIMIT}). */
   limit?: number;
+  /** Filter by the MCP tool name that produced the log entry. */
   tool_name?: string;
+  /** Filter by operation type (e.g. `'search'`, `'read'`, `'create'`). */
   operation?: string;
+  /** Filter by outcome: `'success'` or `'error'`. */
   status?: 'success' | 'error';
+  /** Filter by the Notion page ID the operation targeted. */
   page_id?: string;
+  /** Filter by the Notion database ID the operation targeted. */
   database_id?: string;
+  /** ISO-8601 timestamp lower bound — only entries at or after this time. */
   since?: string;
+  /** Filter by the MCP session that produced the entry. */
   session_id?: string;
+  /** Filter by the agent that produced the entry. */
   agent_id?: string;
+  /** When `true`, JOIN raw HTTP request/response payloads into each row. */
   include_raw?: boolean;
 }
 

--- a/test/audit-logs.test.ts
+++ b/test/audit-logs.test.ts
@@ -240,6 +240,29 @@ describeDb('readAuditLogs — integration', () => {
     expect(row).not.toHaveProperty('state_before');
     expect(row).not.toHaveProperty('state_after');
   });
+
+  it('normalizes since timestamp for boundary filtering', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    // Log an operation and capture its approximate time
+    const beforeLog = new Date().toISOString();
+    logOperation({
+      operation: 'help',
+      toolName: 'notion_help',
+      status: 'success',
+    });
+
+    // Query with a truncated ISO string (no milliseconds) that should still
+    // match, because readAuditLogs normalizes it to canonical form.
+    const truncated = beforeLog.replace(/\.\d{3}Z$/, 'Z');
+    const rows = readAuditLogs({
+      sessionId: testSession,
+      operation: 'help',
+      since: truncated,
+    });
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect((rows[0] as Record<string, unknown>).tool_name).toBe('notion_help');
+  });
 });
 
 describeDb('readAuditLogs — includeRaw path', () => {
@@ -309,6 +332,41 @@ describeDb('readAuditLogs — includeRaw path', () => {
     const row = rows[0] as Record<string, unknown>;
     expect(row.state_before).toBeNull();
     expect(row.state_after).toBeNull();
+  });
+
+  it('redacts sensitive fields from raw_request_headers', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'search',
+      toolName: 'notion_search',
+      status: 'success',
+      rawRequest: {
+        url: 'https://api.notion.com/v1/search',
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ntn_leak_me',
+          'x-api-token': 'secret-token-value',
+          'Content-Type': 'application/json',
+        },
+      },
+    });
+
+    const rows = readAuditLogs({
+      sessionId: testSession,
+      includeRaw: true,
+      toolName: 'notion_search',
+    });
+    const row = rows[0] as Record<string, unknown>;
+    const headers = row.raw_request_headers as Record<string, string> | null;
+    expect(headers).not.toBeNull();
+    if (headers) {
+      // Write-time sanitizer catches Authorization; read-time redaction
+      // catches both Authorization and token-bearing headers.
+      expect(headers.Authorization).toBe('[REDACTED]');
+      expect(headers['x-api-token']).toBe('[REDACTED]');
+      expect(headers['Content-Type']).toBe('application/json');
+    }
   });
 });
 

--- a/test/audit-logs.test.ts
+++ b/test/audit-logs.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the audit log reader, safe JSON parsing, credential redaction,
+ * and limit clamping.
+ *
+ * Unit tests for pure helpers (safeJsonParse, redactSensitiveFields, clampLimit)
+ * run without any database or Notion API access. Integration tests exercise
+ * readAuditLogs and readNotionLogs by writing entries via logOperation then
+ * reading them back through the query layer.
+ *
+ * @module
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  clampLimit,
+  logOperation,
+  readAuditLogs,
+  redactSensitiveFields,
+  safeJsonParse,
+  setAuditContext,
+} from '../src/audit.js';
+import { readNotionLogs } from '../src/tools/logs.js';
+
+/**
+ * Check whether the better-sqlite3 native addon is available.
+ * Integration tests that hit the database are skipped when it isn't.
+ */
+function hasSqliteBindings(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('better-sqlite3');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const sqliteAvailable = hasSqliteBindings();
+const describeDb = sqliteAvailable ? describe : describe.skip;
+
+/* ------------------------------------------------------------------ */
+/*  Unit: safeJsonParse                                                */
+/* ------------------------------------------------------------------ */
+
+describe('safeJsonParse', () => {
+  it('parses valid JSON strings', () => {
+    expect(safeJsonParse('{"a":1}')).toEqual({ a: 1 });
+    expect(safeJsonParse('"hello"')).toBe('hello');
+    expect(safeJsonParse('[1,2,3]')).toEqual([1, 2, 3]);
+    expect(safeJsonParse('null')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(safeJsonParse('{bad json')).toBeNull();
+    expect(safeJsonParse('undefined')).toBeNull();
+    expect(safeJsonParse("{'single': 'quotes'}")).toBeNull();
+  });
+
+  it('returns null for non-string inputs', () => {
+    expect(safeJsonParse(null)).toBeNull();
+    expect(safeJsonParse(undefined)).toBeNull();
+    expect(safeJsonParse(42)).toBeNull();
+    expect(safeJsonParse(true)).toBeNull();
+    expect(safeJsonParse({ already: 'parsed' })).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    // Empty string is invalid JSON
+    expect(safeJsonParse('')).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Unit: redactSensitiveFields                                        */
+/* ------------------------------------------------------------------ */
+
+describe('redactSensitiveFields', () => {
+  it('redacts Authorization headers', () => {
+    const input = {
+      url: 'https://api.notion.com/v1/pages',
+      headers: {
+        Authorization: 'Bearer ntn_secret123',
+        'Content-Type': 'application/json',
+      },
+    };
+    const result = redactSensitiveFields(input) as Record<string, unknown>;
+    const headers = result.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('[REDACTED]');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('redacts fields containing "token" (case-insensitive)', () => {
+    const input = {
+      accessToken: 'secret-value',
+      api_token: 'another-secret',
+      name: 'safe-value',
+    };
+    const result = redactSensitiveFields(input) as Record<string, unknown>;
+    expect(result.accessToken).toBe('[REDACTED]');
+    expect(result.api_token).toBe('[REDACTED]');
+    expect(result.name).toBe('safe-value');
+  });
+
+  it('recurses into nested objects', () => {
+    const input = {
+      outer: {
+        inner: {
+          authorization: 'Bearer xyz',
+          data: 'visible',
+        },
+      },
+    };
+    const result = redactSensitiveFields(input) as Record<string, unknown>;
+    const inner = (result.outer as Record<string, unknown>).inner as Record<string, unknown>;
+    expect(inner.authorization).toBe('[REDACTED]');
+    expect(inner.data).toBe('visible');
+  });
+
+  it('returns primitives and nulls unchanged', () => {
+    expect(redactSensitiveFields(null)).toBeNull();
+    expect(redactSensitiveFields(undefined)).toBeUndefined();
+    expect(redactSensitiveFields('string')).toBe('string');
+    expect(redactSensitiveFields(42)).toBe(42);
+  });
+
+  it('does not recurse into arrays', () => {
+    // Arrays are left as-is (not iterated for key redaction)
+    const input = { items: [{ authorization: 'secret' }] };
+    const result = redactSensitiveFields(input) as Record<string, unknown>;
+    const items = result.items as Array<{ authorization: string }>;
+    // Array values are preserved without deep inspection
+    expect(items[0].authorization).toBe('secret');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Unit: clampLimit                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('clampLimit', () => {
+  it('uses fallback when undefined', () => {
+    expect(clampLimit(undefined)).toBe(20);
+    expect(clampLimit(undefined, 50)).toBe(50);
+  });
+
+  it('passes through valid integers in range', () => {
+    expect(clampLimit(1)).toBe(1);
+    expect(clampLimit(50)).toBe(50);
+    expect(clampLimit(100)).toBe(100);
+  });
+
+  it('caps at 100', () => {
+    expect(clampLimit(200)).toBe(100);
+    expect(clampLimit(999)).toBe(100);
+  });
+
+  it('floors at 0', () => {
+    expect(clampLimit(0)).toBe(0);
+    expect(clampLimit(-1)).toBe(0);
+    expect(clampLimit(-999)).toBe(0);
+  });
+
+  it('rejects non-integer values and returns fallback', () => {
+    expect(clampLimit(3.5)).toBe(20);
+    expect(clampLimit(0.1)).toBe(20);
+    expect(clampLimit(3.5, 10)).toBe(10);
+  });
+
+  it('rejects NaN and Infinity', () => {
+    expect(clampLimit(Number.NaN)).toBe(20);
+    expect(clampLimit(Number.POSITIVE_INFINITY)).toBe(20);
+    expect(clampLimit(Number.NEGATIVE_INFINITY)).toBe(20);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Integration: readAuditLogs + readNotionLogs                        */
+/* ------------------------------------------------------------------ */
+
+describeDb('readAuditLogs — integration', () => {
+  // Use a unique session ID to isolate these test entries from real data
+  const testSession = `vitest-audit-${Date.now()}`;
+
+  it('writes and reads back audit entries', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'read',
+      toolName: 'notion_read',
+      targetPageId: 'page-aaa',
+      status: 'success',
+      durationMs: 42,
+    });
+
+    logOperation({
+      operation: 'create',
+      toolName: 'notion_create',
+      targetPageId: 'page-bbb',
+      status: 'error',
+      errorCode: 'validation_error',
+      errorMessage: 'Missing title',
+      durationMs: 100,
+    });
+
+    const rows = readAuditLogs({ sessionId: testSession });
+    expect(rows.length).toBe(2);
+    // Verify both operations are present (order may vary when timestamps match)
+    const ops = rows.map((r) => (r as Record<string, unknown>).operation);
+    expect(ops).toContain('create');
+    expect(ops).toContain('read');
+  });
+
+  it('filters by status', () => {
+    const errors = readAuditLogs({ sessionId: testSession, status: 'error' });
+    expect(errors.length).toBe(1);
+    expect((errors[0] as Record<string, unknown>).tool_name).toBe('notion_create');
+  });
+
+  it('filters by operation', () => {
+    const reads = readAuditLogs({ sessionId: testSession, operation: 'read' });
+    expect(reads.length).toBe(1);
+    expect((reads[0] as Record<string, unknown>).target_page_id).toBe('page-aaa');
+  });
+
+  it('filters by page_id', () => {
+    const rows = readAuditLogs({ sessionId: testSession, targetPageId: 'page-bbb' });
+    expect(rows.length).toBe(1);
+    expect((rows[0] as Record<string, unknown>).status).toBe('error');
+  });
+
+  it('respects limit', () => {
+    const rows = readAuditLogs({ sessionId: testSession, limit: 1 });
+    expect(rows.length).toBe(1);
+  });
+
+  it('returns compact rows without state_before/state_after by default', () => {
+    const rows = readAuditLogs({ sessionId: testSession, limit: 1 });
+    const row = rows[0] as Record<string, unknown>;
+    // Compact mode omits state columns
+    expect(row).not.toHaveProperty('state_before');
+    expect(row).not.toHaveProperty('state_after');
+  });
+});
+
+describeDb('readAuditLogs — includeRaw path', () => {
+  const testSession = `vitest-raw-${Date.now()}`;
+
+  it('parses state_before/state_after JSON and redacts raw_request_body', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'update',
+      toolName: 'notion_update',
+      targetPageId: 'page-raw',
+      status: 'success',
+      stateBefore: { title: 'Old Title' },
+      stateAfter: { title: 'New Title' },
+      rawRequest: {
+        url: 'https://api.notion.com/v1/pages/page-raw',
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer ntn_supersecret',
+          'Content-Type': 'application/json',
+        },
+      },
+      rawResponse: { statusCode: 200 },
+    });
+
+    const rows = readAuditLogs({ sessionId: testSession, includeRaw: true });
+    expect(rows.length).toBe(1);
+
+    const row = rows[0] as Record<string, unknown>;
+    // State snapshots parsed from JSON
+    expect(row.state_before).toEqual({ title: 'Old Title' });
+    expect(row.state_after).toEqual({ title: 'New Title' });
+
+    // Raw request body is redacted (the body stored is the full rawRequest object)
+    const body = row.raw_request_body as Record<string, unknown> | null;
+    if (body) {
+      // The stored body is JSON.stringify(rawRequest), which includes url/method/headers
+      // redactSensitiveFields should catch Authorization in headers
+      const headers = body.headers as Record<string, string> | undefined;
+      if (headers) {
+        expect(headers.Authorization).toBe('[REDACTED]');
+      }
+    }
+
+    // Raw request headers stored separately should still have redacted auth
+    // (the rawRequestHeaders helper in audit.ts already strips auth at write time)
+    expect(row.raw_request_url).toBe('https://api.notion.com/v1/pages/page-raw');
+    expect(row.raw_request_method).toBe('PATCH');
+  });
+
+  it('survives malformed JSON in state columns', () => {
+    // This tests the safeJsonParse integration path. We can't easily inject
+    // malformed data via logOperation (it JSON.stringifies), but we verify
+    // that null state values are handled.
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'read',
+      toolName: 'notion_read',
+      status: 'success',
+      // No state snapshots — should come back as null
+    });
+
+    const rows = readAuditLogs({ sessionId: testSession, includeRaw: true, operation: 'read' });
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const row = rows[0] as Record<string, unknown>;
+    expect(row.state_before).toBeNull();
+    expect(row.state_after).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Integration: readNotionLogs wrapper                                */
+/* ------------------------------------------------------------------ */
+
+describeDb('readNotionLogs wrapper', () => {
+  const testSession = `vitest-wrapper-${Date.now()}`;
+
+  it('returns { count, rows } shape', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'search',
+      toolName: 'notion_search',
+      status: 'success',
+    });
+
+    const result = readNotionLogs({ session_id: testSession });
+    expect(result).toHaveProperty('count');
+    expect(result).toHaveProperty('rows');
+    expect(result.count).toBe(1);
+    expect(result.rows.length).toBe(1);
+  });
+
+  it('clamps negative limit to 0', () => {
+    const result = readNotionLogs({ session_id: testSession, limit: -5 });
+    expect(result.count).toBe(0);
+  });
+
+  it('clamps fractional limit to default', () => {
+    const result = readNotionLogs({ session_id: testSession, limit: 1.5 });
+    // Fractional -> falls back to default 20, returns whatever matches
+    expect(result.count).toBeLessThanOrEqual(20);
+  });
+
+  it('maps snake_case params to camelCase options', () => {
+    setAuditContext({ agentId: 'test-agent', sessionId: testSession, testRun: true });
+
+    logOperation({
+      operation: 'create',
+      toolName: 'notion_create',
+      targetPageId: 'page-mapped',
+      status: 'error',
+      errorMessage: 'test error',
+    });
+
+    const result = readNotionLogs({
+      session_id: testSession,
+      tool_name: 'notion_create',
+      page_id: 'page-mapped',
+      status: 'error',
+    });
+    expect(result.count).toBe(1);
+    expect((result.rows[0] as Record<string, unknown>).error_message).toBe('test error');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class `notion_logs_read` tool so agents can inspect the audit trail directly without manual database access.

### Changes

**src/audit.ts** — New `readAuditLogs()` function with full filter support, `safeJsonParse` for malformed data resilience, `redactSensitiveFields` for credential scrubbing, `clampLimit` for safe query bounds, and TSDoc on all exports.

**src/tools/logs.ts** — Thin wrapper mapping snake_case tool params to the camelCase query options. Returns `{ count, rows }`.

**src/index.ts** — Registers `notion_logs_read` with TypeBox schema, agent-scoped context (`ctx.agentId` default), `Type.Union` literals for status/direction validation.

**src/tools/help.ts** — Added `notion_logs_read` to the TOOL_DOCS catalogue.

**test/audit-logs.test.ts** — 29 tests: unit tests for pure helpers + integration tests for the full read path.

Supersedes #9 (rebased onto master after #8 merged).

Closes #5

## Summary by Sourcery

Introduce a first-class audit log reading capability and expose it as a Notion MCP tool for agents to inspect local operation history with safety guards.

New Features:
- Add a readAuditLogs API to query audit logs with rich filters and optional inclusion of raw HTTP payloads.
- Expose a notion_logs_read MCP tool and readNotionLogs wrapper that return filtered audit log entries with a consistent { count, rows } shape.
- Document the notion_logs_read tool in the tool help catalogue, including parameters and example usage.

Enhancements:
- Add safeJsonParse, redactSensitiveFields, and clampLimit helpers to make log reading resilient, avoid credential leakage, and enforce safe query bounds.
- Improve audit context and logging TSDoc and comments for clearer operation semantics.

Tests:
- Add comprehensive unit and integration tests for audit log reading, JSON parsing, redaction, limit clamping, and the notion_logs_read wrapper, conditionally running DB-backed tests only when SQLite bindings are available.