### PR TITLE
fix: ensure better-sqlite3 native addon is built in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build native addons
+        run: pnpm rebuild better-sqlite3
+
       - name: Build
         run: pnpm build
 

--- a/test/audit-logs.test.ts
+++ b/test/audit-logs.test.ts
@@ -10,6 +10,8 @@
  * @module
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   clampLimit,
@@ -22,14 +24,17 @@ import {
 import { readNotionLogs } from '../src/tools/logs.js';
 
 /**
- * Check whether the better-sqlite3 native addon is available.
- * Integration tests that hit the database are skipped when it isn't.
+ * Check whether the better-sqlite3 native addon binary exists on disk.
+ * The native binary only compiles when build tools are available (make, g++).
+ * Integration tests that hit the database are skipped when it isn't built.
  */
 function hasSqliteBindings(): boolean {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('better-sqlite3');
-    return true;
+    // Resolve the better-sqlite3 package directory, then check for the compiled binary.
+    const bsqlPath = require.resolve('better-sqlite3');
+    const pkgDir = path.dirname(path.dirname(bsqlPath));
+    const buildDir = path.join(pkgDir, 'build', 'Release');
+    return fs.existsSync(path.join(buildDir, 'better_sqlite3.node'));
   } catch {
     return false;
   }


### PR DESCRIPTION
The audit-logs integration tests need the compiled `better-sqlite3` native binary. `pnpm install --frozen-lockfile` doesn't always trigger the native build step on GitHub Actions runners, so the 14 DB integration tests crash with `Could not locate the bindings file`.

**Changes:**
- Add `pnpm rebuild better-sqlite3` step to the CI test job before build
- Harden the test skip guard to check for the binary on disk via `fs.existsSync` instead of `require()` which vitest's ESM shim can intercept

Fixes the CI failure on #11.

## Summary by Sourcery

Ensure better-sqlite3 native addon is reliably available for audit log integration tests in CI.

Bug Fixes:
- Guard audit log database integration tests by checking for the compiled better-sqlite3 binary on disk instead of relying on require interception.
- Rebuild the better-sqlite3 native addon during the CI quality workflow to prevent missing binding failures.

CI:
- Add a dedicated step in the CI quality workflow to rebuild the better-sqlite3 native addon before building and running tests.