### PR TITLE
fix: allow pnpm 10 to build better-sqlite3 native addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "vitest": "^4.1.4"
   },
   "type": "module",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  },
   "packageManager": "pnpm@10.33.0",
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Problem

pnpm 10 (released Jan 2025) blocks lifecycle scripts by default for security reasons. When `pnpm install --frozen-lockfile` runs in CI, better-sqlite3's install script (`prebuild-install || node-gyp rebuild --release`) never executes, so the native `.node` binary is never downloaded or compiled. Tests then crash with `Could not locate the bindings file`.

## Fix

Add `better-sqlite3` to `pnpm.onlyBuiltDependencies` in package.json. This is the standard pnpm 10 approach used by Drizzle ORM, better-auth, Strapi, and other projects with native addon dependencies.

No CI workflow changes needed. `pnpm install --frozen-lockfile` now runs the install script, which downloads the prebuilt binary (available for ubuntu-latest + Node 22).

## What this replaces

The previous attempt (PR #12 / branch `fix/ci-audit-tests`) used `pnpm rebuild better-sqlite3` as a separate CI step, which worked but was a workaround for the wrong problem.