### PR TITLE
fix: sync roundtrip issues — child page tags, push errors, italic drift

### DIFF
--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -15,13 +15,14 @@ import * as path from 'node:path';
 import type { Client } from '@notionhq/client';
 import matter from 'gray-matter';
 import { getMarkdownPagesApi } from '../client.js';
+import { DEFAULT_PAGE_SIZE } from '../constants.js';
 import {
   extractPageTitle,
   findTitlePropertyName,
   isRecord,
   retrievePageMetadata,
 } from '../helpers.js';
-import type { AnyPage, LocalFileState, SyncParams } from '../types.js';
+import type { AnyBlock, AnyPage, LocalFileState, SyncParams } from '../types.js';
 
 /**
  * Read and parse a local markdown file, extracting frontmatter and stats.
@@ -193,6 +194,9 @@ function resolveSyncDirection(
  * After writing, stamps `notion_id` into the local frontmatter for
  * subsequent round-trip syncs.
  *
+ * When updating, wraps the Notion API error with the page ID and a hint
+ * about the child-page safety check so failures are diagnosable.
+ *
  * @returns The final page object and refreshed local mtime.
  * @throws {Error} When the local file does not exist or no parent is given for creation.
  */
@@ -223,11 +227,24 @@ async function pushLocalFile(
       markdown: localState.content,
     })) as AnyPage;
   } else {
-    await getMarkdownPagesApi(notion).updateMarkdown({
-      page_id: pageId,
-      type: 'replace_content',
-      replace_content: { new_str: localState.content },
-    });
+    try {
+      await getMarkdownPagesApi(notion).updateMarkdown({
+        page_id: pageId,
+        type: 'replace_content',
+        replace_content: { new_str: localState.content },
+      });
+    } catch (error) {
+      // Surface Notion's error details so the caller can diagnose the failure.
+      // The API returns structured errors for child-page safety violations and
+      // block creation failures, but the SDK wraps them in generic errors.
+      const detail = extractNotionErrorDetail(error);
+      throw new Error(
+        `Failed to push content to page ${pageId}: ${detail}\n` +
+          `Hint: if the page has child pages or databases, ensure the local file ` +
+          `contains <page url="...">Title</page> tags for each child. ` +
+          `Pull the page first to get the correct references.`
+      );
+    }
     finalPage = await updatePageTitleIfPossible(notion, pageId, title);
   }
 
@@ -243,7 +260,185 @@ async function pushLocalFile(
 }
 
 /**
+ * Extract a human-readable error message from a Notion SDK error.
+ *
+ * The SDK wraps API errors in objects with `body`, `message`, `code`, and
+ * `status` properties. This helper digs through those layers so push failures
+ * include the server's actual complaint (e.g. which child pages would be
+ * deleted, or which block failed to create).
+ *
+ * @param error - Caught error from a Notion SDK call.
+ * @returns A descriptive error string.
+ */
+function extractNotionErrorDetail(error: unknown): string {
+  if (!isRecord(error)) return String(error);
+
+  // The SDK typically puts the API message on error.message and the full body
+  // on error.body (a string or object).
+  const parts: string[] = [];
+
+  if (typeof error.message === 'string') {
+    parts.push(error.message);
+  }
+  if (typeof error.code === 'string') {
+    parts.push(`[${error.code}]`);
+  }
+  if (typeof error.body === 'string') {
+    parts.push(error.body);
+  } else if (isRecord(error.body) && typeof error.body.message === 'string') {
+    parts.push(error.body.message);
+  }
+
+  return parts.length > 0 ? parts.join(' — ') : String(error);
+}
+
+/**
+ * Normalise underscore-delimited italics to asterisk-delimited italics.
+ *
+ * Notion's enhanced markdown format specifies `*text*` for italics, but some
+ * content round-trips through `_text_` depending on the original source.
+ * Normalising on pull prevents cosmetic diffs from accumulating across
+ * pull-push cycles.
+ *
+ * Skips content inside code fences and inline code spans to avoid mangling
+ * code samples.
+ *
+ * @param markdown - Raw markdown string from Notion.
+ * @returns Markdown with underscore italics replaced by asterisk italics.
+ */
+function normalizeItalics(markdown: string): string {
+  // Split on code fences and inline code so we only transform prose regions.
+  // Fenced code blocks: ```...``` (greedy, multiline)
+  // Inline code: `...` (non-greedy, single line)
+  const codePattern = /(```[\s\S]*?```|`[^`]+`)/g;
+  const parts = markdown.split(codePattern);
+
+  for (let i = 0; i < parts.length; i++) {
+    // Even indices are prose, odd indices are code (captured by the split regex).
+    if (i % 2 === 0) {
+      // Replace _word_ patterns that aren't inside a larger word (bounded by
+      // non-word chars or start/end of string). Handles multi-word spans like
+      // _some phrase here_ by matching across spaces.
+      parts[i] = parts[i].replace(/(?<=^|[^\\a-zA-Z0-9])_([^\n_]+?)_(?=[^a-zA-Z0-9]|$)/g, '*$1*');
+    }
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Enumerate child pages and databases for a Notion page.
+ *
+ * Walks the page's block children to find `child_page` and `child_database`
+ * blocks. Returns an array of `{ id, title, type, url }` objects.
+ *
+ * @param notion - Authenticated Notion client.
+ * @param pageId - UUID of the parent page.
+ * @returns Array of child page/database descriptors.
+ */
+async function enumerateChildBlocks(
+  notion: Client,
+  pageId: string
+): Promise<
+  Array<{ id: string; title: string; type: 'child_page' | 'child_database'; url: string | null }>
+> {
+  const children: Array<{
+    id: string;
+    title: string;
+    type: 'child_page' | 'child_database';
+    url: string | null;
+  }> = [];
+  let startCursor: string | undefined;
+
+  do {
+    const response = await notion.blocks.children.list({
+      block_id: pageId,
+      start_cursor: startCursor,
+      page_size: DEFAULT_PAGE_SIZE,
+    });
+
+    for (const block of response.results) {
+      const b = block as AnyBlock;
+      if (b.type === 'child_page') {
+        const childPage = b.child_page as { title?: string } | undefined;
+        const title = childPage?.title ?? 'Untitled';
+        const page = await retrievePageMetadata(notion, b.id);
+        children.push({ id: b.id, title, type: 'child_page', url: page.url ?? null });
+      } else if (b.type === 'child_database') {
+        const childDb = b.child_database as { title?: string } | undefined;
+        const title = childDb?.title ?? 'Untitled';
+        children.push({ id: b.id, title, type: 'child_database', url: null });
+      }
+    }
+
+    startCursor = response.next_cursor ?? undefined;
+  } while (startCursor);
+
+  return children;
+}
+
+/**
+ * Append child page/database reference tags to pulled markdown.
+ *
+ * The Notion retrieveMarkdown endpoint may omit `<page>` tags for child pages
+ * the integration can see through the block API but that aren't represented in
+ * the enhanced markdown output. Appending these tags ensures the pulled content
+ * is push-safe: pushing it back won't trigger Notion's child-page safety error.
+ *
+ * Only appends tags for children whose URLs don't already appear in the markdown.
+ *
+ * @param markdown - Enhanced markdown string from retrieveMarkdown.
+ * @param children - Child blocks discovered via blocks.children.list.
+ * @returns Markdown with any missing child reference tags appended.
+ */
+function appendMissingChildTags(
+  markdown: string,
+  children: Array<{
+    id: string;
+    title: string;
+    type: 'child_page' | 'child_database';
+    url: string | null;
+  }>
+): string {
+  if (children.length === 0) return markdown;
+
+  const missingTags: string[] = [];
+
+  for (const child of children) {
+    // Check if this child is already referenced in the markdown by its URL or ID.
+    // The enhanced markdown format uses <page url="..."> or the ID might appear
+    // in an <unknown> tag or inline reference.
+    const idNoDashes = child.id.replace(/-/g, '');
+    const alreadyReferenced =
+      (child.url && markdown.includes(child.url)) ||
+      markdown.includes(child.id) ||
+      markdown.includes(idNoDashes);
+
+    if (!alreadyReferenced) {
+      if (child.type === 'child_page') {
+        // Use Notion's enhanced markdown format for child page references.
+        const url = child.url ?? `https://www.notion.so/${idNoDashes}`;
+        missingTags.push(`<page url="${url}">${child.title}</page>`);
+      } else {
+        const url = `https://www.notion.so/${idNoDashes}`;
+        missingTags.push(`<database url="${url}">${child.title}</database>`);
+      }
+    }
+  }
+
+  if (missingTags.length === 0) return markdown;
+
+  // Append after a blank line so the tags don't merge with existing content.
+  const separator = markdown.endsWith('\n') ? '\n' : '\n\n';
+  return `${markdown}${separator}${missingTags.join('\n')}\n`;
+}
+
+/**
  * Pull a Notion page's content into a local markdown file.
+ *
+ * Discovers child pages/databases via the block API and appends reference tags
+ * for any that the retrieveMarkdown endpoint omitted. Normalises italic syntax
+ * to asterisks so pull-push round-trips don't generate cosmetic diffs.
  *
  * @returns The page object and refreshed local mtime.
  */
@@ -260,10 +455,20 @@ async function pullRemotePage(
     notion_id: page.id,
     title: extractPageTitle(page),
   };
-  const markdown = markdownPage.markdown;
-  if (typeof markdown !== 'string') {
+  const rawMarkdown = markdownPage.markdown;
+  if (typeof rawMarkdown !== 'string') {
     throw new Error('Expected markdownPage.markdown to be a string');
   }
+  let markdown: string = rawMarkdown;
+
+  // Discover child pages/databases and ensure they're referenced in the
+  // markdown so a subsequent push won't trigger Notion's safety error.
+  const children = await enumerateChildBlocks(notion, pageId);
+  markdown = appendMissingChildTags(markdown, children);
+
+  // Normalise underscore italics to asterisk italics to prevent cosmetic drift.
+  markdown = normalizeItalics(markdown);
+
   await writeMarkdownFile(localState.absolutePath, markdown, mergedData);
   const refreshedStat = await fsp.stat(localState.absolutePath);
 

--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -242,7 +242,8 @@ async function pushLocalFile(
         `Failed to push content to page ${pageId}: ${detail}\n` +
           `Hint: if the page has child pages or databases, ensure the local file ` +
           `contains <page url="...">Title</page> tags for each child. ` +
-          `Pull the page first to get the correct references.`
+          `Pull the page first to get the correct references.`,
+        { cause: error }
       );
     }
     finalPage = await updatePageTitleIfPossible(notion, pageId, title);
@@ -300,26 +301,27 @@ function extractNotionErrorDetail(error: unknown): string {
  * Normalising on pull prevents cosmetic diffs from accumulating across
  * pull-push cycles.
  *
- * Skips content inside code fences and inline code spans to avoid mangling
- * code samples.
+ * Skips content inside code fences, inline code spans, and link targets
+ * `[text](url)` to avoid mangling code samples or URLs containing underscores.
+ * Also avoids rewriting `__bold__` (double-underscore) delimiters.
  *
  * @param markdown - Raw markdown string from Notion.
  * @returns Markdown with underscore italics replaced by asterisk italics.
  */
 function normalizeItalics(markdown: string): string {
-  // Split on code fences and inline code so we only transform prose regions.
-  // Fenced code blocks: ```...``` (greedy, multiline)
-  // Inline code: `...` (non-greedy, single line)
-  const codePattern = /(```[\s\S]*?```|`[^`]+`)/g;
-  const parts = markdown.split(codePattern);
+  // Split on code fences, inline code, and markdown link targets so we only
+  // transform prose regions. Link targets are excluded because URLs often
+  // contain underscores (e.g. https://example.com/_docs_/v1).
+  const protectedPattern = /(```[\s\S]*?```|`[^`]+`|\]\([^)]*\))/g;
+  const parts = markdown.split(protectedPattern);
 
   for (let i = 0; i < parts.length; i++) {
-    // Even indices are prose, odd indices are code (captured by the split regex).
+    // Even indices are prose, odd indices are protected (captured by the split regex).
     if (i % 2 === 0) {
-      // Replace _word_ patterns that aren't inside a larger word (bounded by
-      // non-word chars or start/end of string). Handles multi-word spans like
-      // _some phrase here_ by matching across spaces.
-      parts[i] = parts[i].replace(/(?<=^|[^\\a-zA-Z0-9])_([^\n_]+?)_(?=[^a-zA-Z0-9]|$)/g, '*$1*');
+      // Match single-underscore emphasis that isn't part of a __bold__ pair.
+      // Capture the leading boundary character so we can reinsert it, avoiding
+      // variable-length lookbehind which is unreliable across JS engines.
+      parts[i] = parts[i].replace(/(^|[^\\a-zA-Z0-9_])_([^\n_]+?)_(?=[^a-zA-Z0-9_]|$)/g, '$1*$2*');
     }
   }
 
@@ -330,7 +332,8 @@ function normalizeItalics(markdown: string): string {
  * Enumerate child pages and databases for a Notion page.
  *
  * Walks the page's block children to find `child_page` and `child_database`
- * blocks. Returns an array of `{ id, title, type, url }` objects.
+ * blocks. Builds deterministic Notion URLs from block IDs instead of making
+ * per-child API calls, avoiding N+1 request patterns and rate-limit pressure.
  *
  * @param notion - Authenticated Notion client.
  * @param pageId - UUID of the parent page.
@@ -362,8 +365,15 @@ async function enumerateChildBlocks(
       if (b.type === 'child_page') {
         const childPage = b.child_page as { title?: string } | undefined;
         const title = childPage?.title ?? 'Untitled';
-        const page = await retrievePageMetadata(notion, b.id);
-        children.push({ id: b.id, title, type: 'child_page', url: page.url ?? null });
+        // Build the URL from the block ID to avoid an extra API call per child.
+        // appendMissingChildTags uses this for the <page url="..."> tag.
+        const idNoDashes = b.id.replace(/-/g, '');
+        children.push({
+          id: b.id,
+          title,
+          type: 'child_page',
+          url: `https://www.notion.so/${idNoDashes}`,
+        });
       } else if (b.type === 'child_database') {
         const childDb = b.child_database as { title?: string } | undefined;
         const title = childDb?.title ?? 'Untitled';
@@ -378,6 +388,30 @@ async function enumerateChildBlocks(
 }
 
 /**
+ * Escape characters that are special in XML/HTML attribute values.
+ *
+ * @param value - Raw attribute string (typically a URL).
+ * @returns Escaped string safe for use inside double-quoted attributes.
+ */
+function escapeTagAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Escape characters that are special in XML/HTML text content.
+ *
+ * @param value - Raw text (typically a page or database title).
+ * @returns Escaped string safe for use as element text content.
+ */
+function escapeTagText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
  * Append child page/database reference tags to pulled markdown.
  *
  * The Notion retrieveMarkdown endpoint may omit `<page>` tags for child pages
@@ -385,7 +419,9 @@ async function enumerateChildBlocks(
  * the enhanced markdown output. Appending these tags ensures the pulled content
  * is push-safe: pushing it back won't trigger Notion's child-page safety error.
  *
- * Only appends tags for children whose URLs don't already appear in the markdown.
+ * Only appends tags for children not already referenced via `<page url="...">`
+ * or `<database url="...">` patterns in the markdown. Titles and URLs are
+ * XML-escaped to prevent malformed markup from unusual page names.
  *
  * @param markdown - Enhanced markdown string from retrieveMarkdown.
  * @param children - Child blocks discovered via blocks.children.list.
@@ -405,25 +441,19 @@ function appendMissingChildTags(
   const missingTags: string[] = [];
 
   for (const child of children) {
-    // Check if this child is already referenced in the markdown by its URL or ID.
-    // The enhanced markdown format uses <page url="..."> or the ID might appear
-    // in an <unknown> tag or inline reference.
     const idNoDashes = child.id.replace(/-/g, '');
-    const alreadyReferenced =
-      (child.url && markdown.includes(child.url)) ||
-      markdown.includes(child.id) ||
-      markdown.includes(idNoDashes);
 
-    if (!alreadyReferenced) {
-      if (child.type === 'child_page') {
-        // Use Notion's enhanced markdown format for child page references.
-        const url = child.url ?? `https://www.notion.so/${idNoDashes}`;
-        missingTags.push(`<page url="${url}">${child.title}</page>`);
-      } else {
-        const url = `https://www.notion.so/${idNoDashes}`;
-        missingTags.push(`<database url="${url}">${child.title}</database>`);
-      }
-    }
+    // Check for actual enhanced-markdown reference tags or <unknown> tags that
+    // contain this child's ID, rather than a loose substring match that could
+    // false-positive on unrelated content.
+    const tagPattern = new RegExp(`<(?:page|database|unknown)[^>]*(?:${child.id}|${idNoDashes})`);
+    if (tagPattern.test(markdown)) continue;
+
+    const url = child.url ?? `https://www.notion.so/${idNoDashes}`;
+    const tagName = child.type === 'child_page' ? 'page' : 'database';
+    missingTags.push(
+      `<${tagName} url="${escapeTagAttribute(url)}">${escapeTagText(child.title)}</${tagName}>`
+    );
   }
 
   if (missingTags.length === 0) return markdown;
@@ -459,15 +489,21 @@ async function pullRemotePage(
   if (typeof rawMarkdown !== 'string') {
     throw new Error('Expected markdownPage.markdown to be a string');
   }
+  if (markdownPage.truncated === true) {
+    throw new Error(
+      `Refusing to write truncated markdown for page ${pageId}; pull would not be round-trip safe.`
+    );
+  }
   let markdown: string = rawMarkdown;
+
+  // Normalise underscore italics to asterisk italics BEFORE appending child
+  // tags, so the normaliser never touches the generated <page>/<database> markup.
+  markdown = normalizeItalics(markdown);
 
   // Discover child pages/databases and ensure they're referenced in the
   // markdown so a subsequent push won't trigger Notion's safety error.
   const children = await enumerateChildBlocks(notion, pageId);
   markdown = appendMissingChildTags(markdown, children);
-
-  // Normalise underscore italics to asterisk italics to prevent cosmetic drift.
-  markdown = normalizeItalics(markdown);
 
   await writeMarkdownFile(localState.absolutePath, markdown, mergedData);
   const refreshedStat = await fsp.stat(localState.absolutePath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,11 +121,26 @@ export type LocalFileState = {
  */
 export type MarkdownPageApi = {
   retrieveMarkdown: (args: { page_id: string }) => Promise<LooseRecord>;
-  updateMarkdown: (args: {
-    page_id: string;
-    type: 'replace_content';
-    replace_content: { new_str: string };
-  }) => Promise<LooseRecord>;
+  updateMarkdown: (
+    args:
+      | {
+          page_id: string;
+          type: 'replace_content';
+          replace_content: { new_str: string; allow_deleting_content?: boolean };
+        }
+      | {
+          page_id: string;
+          type: 'update_content';
+          update_content: {
+            content_updates: Array<{
+              old_str: string;
+              new_str: string;
+              replace_all_matches?: boolean;
+            }>;
+            allow_deleting_content?: boolean;
+          };
+        }
+  ) => Promise<LooseRecord>;
 };
 
 /** Shape returned by both `databases.query` and `dataSources.query`. */

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -164,4 +164,80 @@ Just content.`,
     );
     await expect(syncNotionFile(notion, { path: filePath, direction: 'pull' })).rejects.toThrow();
   });
+
+  it('pull: includes <page> reference tags for child pages', async () => {
+    // Create a parent page with a child page underneath it.
+    const parentFile = path.join(tmpDir, 'parent-with-child.md');
+    fs.writeFileSync(parentFile, `# Parent\n\nSome content.`, 'utf8');
+    const parent = await syncNotionFile(notion, {
+      path: parentFile,
+      parent_id: parentId,
+      direction: 'push',
+    });
+
+    // Create a child page under the parent.
+    const childPage = (await notion.pages.create({
+      parent: { page_id: parent.page_id },
+      properties: {
+        title: { title: [{ type: 'text', text: { content: 'Child Page' } }] },
+      },
+      markdown: '# Child\n\nChild content.',
+    })) as { id: string };
+
+    // Pull the parent page — it should include a <page> tag for the child.
+    const pullFile = path.join(tmpDir, 'parent-pulled.md');
+    const result = await syncNotionFile(notion, {
+      path: pullFile,
+      page_id: parent.page_id,
+      direction: 'pull',
+    });
+
+    expect(result.direction).toBe('pull');
+    const content = fs.readFileSync(pullFile, 'utf8');
+    const childIdNoDashes = childPage.id.replace(/-/g, '');
+    expect(content).toMatch(new RegExp(`<page[^>]*${childIdNoDashes}`));
+  }, 40000);
+
+  it('pull: normalises underscore italics to asterisks', async () => {
+    // Create a page with underscore-style italics.
+    const page = (await notion.pages.create({
+      parent: { page_id: parentId },
+      properties: {
+        title: { title: [{ type: 'text', text: { content: 'Italic Test' } }] },
+      },
+      markdown: 'Some _italic text_ here.',
+    })) as { id: string };
+
+    const pullFile = path.join(tmpDir, 'italic-test.md');
+    await syncNotionFile(notion, {
+      path: pullFile,
+      page_id: page.id,
+      direction: 'pull',
+    });
+
+    const content = fs.readFileSync(pullFile, 'utf8');
+    // Should have been normalised to asterisk italics.
+    expect(content).not.toContain('_italic text_');
+    expect(content).toContain('*italic text*');
+  }, 20000);
+
+  it('pull: preserves underscores inside inline code', async () => {
+    const page = (await notion.pages.create({
+      parent: { page_id: parentId },
+      properties: {
+        title: { title: [{ type: 'text', text: { content: 'Code Underscore Test' } }] },
+      },
+      markdown: 'Use `some_var_name` in your code.',
+    })) as { id: string };
+
+    const pullFile = path.join(tmpDir, 'code-underscore-test.md');
+    await syncNotionFile(notion, {
+      path: pullFile,
+      page_id: page.id,
+      direction: 'pull',
+    });
+
+    const content = fs.readFileSync(pullFile, 'utf8');
+    expect(content).toContain('`some_var_name`');
+  }, 20000);
 });


### PR DESCRIPTION
## Summary

Fixes three `notion_sync` round-trip issues discovered when testing pull→push on 20 pages.

### 1. Pull emits `<page>` tags for child pages/databases

The `retrieveMarkdown` endpoint sometimes omits child page references from its output. When the pulled content is pushed back, Notion's safety check sees those children would be deleted and rejects the operation.

Pull now enumerates child blocks via `blocks.children.list` after retrieving markdown, and appends `<page url="...">Title</page>` (or `<database>`) tags for any children not already referenced. Pulled files are push-safe by default.

### 2. Push surfaces Notion API error details

Before: `Failed to create block` with no context.

After: the error includes the Notion API's actual message, error code, and response body. Adds a hint directing users to pull first if child page references are missing.

### 3. Pull normalises underscore italics to asterisks

Notion's enhanced markdown format specifies `*text*` for italics, but some content arrives as `_text_`. Normalising on pull prevents cosmetic diffs from accumulating across pull-push cycles. Code blocks and inline code are left untouched.

### Bonus: expanded `MarkdownPageApi` type

The type union now also covers `update_content` (search-and-replace) and the `allow_deleting_content` option on both commands.

## Changes

- `src/tools/sync.ts` — `normalizeItalics`, `enumerateChildBlocks`, `appendMissingChildTags`, `extractNotionErrorDetail` helpers; updated `pullRemotePage` and `pushLocalFile`
- `src/types.ts` — expanded `MarkdownPageApi` type

## Testing

These fixes address live-workspace behavior (child page enumeration, API error formats) that can't be fully unit-tested without a Notion workspace with subpages. The existing test suite continues to pass for the basic push/pull/auto flows.

Closes #14

## Summary by Sourcery

Improve Notion markdown sync reliability and diagnostics for pull/push round trips.

Bug Fixes:
- Prevent push failures by appending missing child page and database reference tags to pulled markdown using block-level child enumeration.
- Avoid cosmetic markdown diffs across sync cycles by normalising underscore italics to asterisk italics on pull.
- Expose detailed Notion API error information on push failures so users can diagnose issues like child-page safety checks.

Enhancements:
- Extend the markdown pages API type to support both replace and update content operations with optional content deletion flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible content replacement operations for more precise markdown updates
  * Enhanced child page and database reference detection and inclusion in synced content

* **Bug Fixes**
  * Improved Notion sync error messages with additional context and page references
  * Fixed italic text formatting normalization across synced markdown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->