### PR TITLE
feat: add notion_upload_file tool for binary file attachments

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -38,7 +38,8 @@ export type Operation =
   | 'sync_pull'
   | 'sync_auto'
   | 'help'
-  | 'doctor';
+  | 'doctor'
+  | 'upload_file';
 
 /**
  * Caller-supplied context attached to every audit log entry.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * openclaw-notion — OpenClaw plugin entry point.
  *
- * Registers 18 Notion tools with the OpenClaw plugin SDK. Each tool
+ * Registers 19 Notion tools with the OpenClaw plugin SDK. Each tool
  * resolves an agent-scoped Notion client via {@link getClient}, ensuring
  * workspace isolation between agents.
  *
@@ -23,7 +23,8 @@ import { readNotionLogs } from './tools/logs.js';
 import { deleteNotionPage, moveNotionPage, publishNotionPage } from './tools/pages.js';
 import { queryNotionDatabase } from './tools/query.js';
 import { syncNotionFile } from './tools/sync.js';
-import type { AnyPage, SyncParams } from './types.js';
+import { uploadNotionFile } from './tools/upload.js';
+import type { AnyPage, SyncParams, UploadParams } from './types.js';
 
 // ── Re-exports for test access ──────────────────────────────────────────
 export { getClient, getMarkdownPagesApi } from './client.js';
@@ -42,6 +43,7 @@ export {
   normalizeItalics,
   syncNotionFile,
 } from './tools/sync.js';
+export { uploadNotionFile } from './tools/upload.js';
 
 /**
  * Build a single paragraph block for the Notion append endpoint.
@@ -533,6 +535,39 @@ export default definePluginEntry({
           fn: async () => {
             return asJsonContent(
               await syncNotionFile(getClient(ctx.agentId), params as SyncParams)
+            );
+          },
+        });
+      },
+    }));
+
+    // --- notion_upload_file ---
+    api.registerTool((ctx) => ({
+      name: 'notion_upload_file',
+      label: 'Notion Upload File',
+      description: 'Upload a local file to Notion and attach it as a file block on a page.',
+      parameters: Type.Object({
+        file_path: Type.String({ description: 'Local filesystem path to the file to upload.' }),
+        page_id: Type.String({ description: 'The UUID of the target Notion page.' }),
+        display_name: Type.Optional(
+          Type.String({ description: 'Optional display name for the file in Notion.' })
+        ),
+        content_type: Type.Optional(
+          Type.String({
+            description: 'Optional MIME type override. Auto-detected from extension when omitted.',
+          })
+        ),
+      }),
+      async execute(_id, params) {
+        return withAudit({
+          operation: 'upload_file',
+          toolName: 'notion_upload_file',
+          agentId: ctx.agentId,
+          targetPageId: params.page_id,
+          localPath: params.file_path,
+          fn: async () => {
+            return asJsonContent(
+              await uploadNotionFile(getClient(ctx.agentId), params as UploadParams)
             );
           },
         });

--- a/src/tools/help.ts
+++ b/src/tools/help.ts
@@ -126,6 +126,17 @@ export const TOOL_DOCS: ToolDoc[] = [
     example: '{}',
   },
   {
+    name: 'notion_upload_file',
+    description: 'Upload a local file to Notion and attach it as a file block on a page.',
+    parameters: [
+      'file_path: string',
+      'page_id: string',
+      'display_name?: string',
+      'content_type?: string',
+    ],
+    example: '{"file_path":"./report.pdf","page_id":"<page-id>","display_name":"Q4 Report.pdf"}',
+  },
+  {
     name: 'notion_logs_read',
     description:
       'Read audit log entries from the local notion-operations.db with optional filters.',

--- a/src/tools/upload.ts
+++ b/src/tools/upload.ts
@@ -1,0 +1,152 @@
+/**
+ * Upload a local file to Notion and attach it to a page.
+ *
+ * Uses the Notion SDK's fileUploads API (single-part mode) to stream a local
+ * file into Notion's storage, then appends a file block referencing the upload
+ * to the target page.
+ */
+
+import { createReadStream } from 'node:fs';
+import { access, stat } from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Client } from '@notionhq/client';
+import type { AnyPage, FileUploadsApi, UploadParams } from '../types.js';
+
+/**
+ * Extension-to-MIME-type map for common file types.
+ *
+ * Avoids pulling in a heavy dependency (e.g. `mime-types`) for a small set of
+ * well-known extensions the Notion API is likely to encounter.
+ */
+const MIME_TYPES: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.mp4': 'video/mp4',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.zip': 'application/zip',
+  '.json': 'application/json',
+  '.csv': 'text/csv',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+/**
+ * Resolve a MIME type from a filename extension.
+ *
+ * Falls back to `application/octet-stream` for unknown extensions so uploads
+ * never fail due to missing content-type metadata.
+ *
+ * @param filename - The file name or path to inspect.
+ * @returns A MIME type string suitable for the `content_type` upload param.
+ */
+function inferContentType(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  return MIME_TYPES[ext] ?? 'application/octet-stream';
+}
+
+/**
+ * Upload a local file to Notion and attach it as a file block on a page.
+ *
+ * The three-step process:
+ * 1. Create a single-part file upload via the Notion API.
+ * 2. Stream the file binary to the upload endpoint.
+ * 3. Append a `file` block referencing the uploaded file to the target page.
+ *
+ * @param notion - An agent-scoped Notion SDK client.
+ * @param params - Upload parameters including the local path and target page.
+ * @returns Metadata about the upload and the target page URL.
+ * @throws {Error} When the file does not exist, is not readable, or any
+ *   Notion API call fails.
+ */
+export async function uploadNotionFile(
+  notion: Client,
+  params: UploadParams
+): Promise<{
+  file_upload_id: string;
+  filename: string;
+  content_type: string;
+  page_id: string;
+  page_url: string | null;
+}> {
+  const absolutePath = path.resolve(params.file_path);
+
+  // Validate the file exists and is readable before touching the Notion API.
+  // access() throws a descriptive ENOENT/EACCES error on failure.
+  await access(absolutePath);
+
+  const fileStat = await stat(absolutePath);
+  if (!fileStat.isFile()) {
+    throw new Error(`Path is not a regular file: ${absolutePath}`);
+  }
+
+  const filename = params.display_name ?? path.basename(absolutePath);
+  const contentType = params.content_type ?? inferContentType(absolutePath);
+
+  // Step 1: Create a file upload slot in Notion.
+  // The SDK types haven't caught up with fileUploads yet, so cast through
+  // unknown to our typed interface — same pattern as getMarkdownPagesApi.
+  const fileUploadsApi = notion.fileUploads as unknown as FileUploadsApi;
+  const fileUpload = await fileUploadsApi.create({
+    filename,
+    content_type: contentType,
+    mode: 'single_part',
+  });
+
+  const fileUploadId: string = fileUpload.id;
+
+  // Step 2: Stream the file binary to Notion.
+  // createReadStream avoids loading the entire file into memory.
+  const readStream = createReadStream(absolutePath);
+  await fileUploadsApi.send({
+    file_upload_id: fileUploadId,
+    file: readStream,
+    filename,
+  });
+
+  // Step 3: Attach the uploaded file to the target page as a file block.
+  // The `uploaded_file` block variant isn't in the SDK types yet, so we
+  // cast through unknown to satisfy the append signature.
+  const fileBlock = {
+    type: 'file' as const,
+    file: {
+      type: 'uploaded_file' as const,
+      uploaded_file: { id: fileUploadId },
+    },
+  };
+  await notion.blocks.children.append({
+    block_id: params.page_id,
+    children: [fileBlock] as unknown as Parameters<
+      typeof notion.blocks.children.append
+    >[0]['children'],
+  });
+
+  // Retrieve the page to surface its URL in the response.
+  let pageUrl: string | null = null;
+  try {
+    const page = (await notion.pages.retrieve({ page_id: params.page_id })) as AnyPage;
+    pageUrl = page.url ?? null;
+  } catch {
+    // Non-fatal: the upload succeeded even if we can't resolve the page URL.
+  }
+
+  return {
+    file_upload_id: fileUploadId,
+    filename,
+    content_type: contentType,
+    page_id: params.page_id,
+    page_url: pageUrl,
+  };
+}

--- a/src/tools/upload.ts
+++ b/src/tools/upload.ts
@@ -93,7 +93,18 @@ export async function uploadNotionFile(
   }
 
   const filename = params.display_name ?? path.basename(absolutePath);
-  const contentType = params.content_type ?? inferContentType(absolutePath);
+  // Infer MIME type from display_name if provided (it may have a different
+  // extension than the local file), falling back to the actual file path.
+  const contentType =
+    params.content_type?.trim() || inferContentType(params.display_name ?? absolutePath);
+
+  // Guard against SDK versions that predate the fileUploads namespace.
+  if (!notion.fileUploads) {
+    throw new Error(
+      'Notion client does not support file uploads. ' +
+        'Upgrade @notionhq/client to v5.12.0+ and set notionVersion to 2026-03-11.'
+    );
+  }
 
   // Step 1: Create a file upload slot in Notion.
   // The SDK types haven't caught up with fileUploads yet, so cast through
@@ -110,11 +121,17 @@ export async function uploadNotionFile(
   // Step 2: Stream the file binary to Notion.
   // createReadStream avoids loading the entire file into memory.
   const readStream = createReadStream(absolutePath);
-  await fileUploadsApi.send({
-    file_upload_id: fileUploadId,
-    file: readStream,
-    filename,
-  });
+  try {
+    await fileUploadsApi.send({
+      file_upload_id: fileUploadId,
+      file: readStream,
+      filename,
+    });
+  } finally {
+    // Ensure the stream is closed even if send() rejects, preventing
+    // file descriptor leaks on large or failing uploads.
+    readStream.destroy();
+  }
 
   // Step 3: Attach the uploaded file to the target page as a file block.
   // The `uploaded_file` block variant isn't in the SDK types yet, so we

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,33 @@ export type SyncParams = {
   direction?: 'push' | 'pull' | 'auto';
 };
 
+/** Parameters accepted by {@link uploadNotionFile}. */
+export type UploadParams = {
+  file_path: string;
+  page_id: string;
+  display_name?: string;
+  content_type?: string;
+};
+
+/**
+ * Capability interface for the Notion SDK's fileUploads namespace.
+ *
+ * The SDK types haven't caught up with the fileUploads API yet, so we define
+ * the subset we use to avoid raw `any` casts throughout upload code.
+ */
+export type FileUploadsApi = {
+  create: (args: {
+    filename: string;
+    content_type: string;
+    mode: 'single_part';
+  }) => Promise<{ id: string; upload_url: string }>;
+  send: (args: {
+    file_upload_id: string;
+    file: import('node:fs').ReadStream;
+    filename: string;
+  }) => Promise<LooseRecord>;
+};
+
 /** Parameters accepted by {@link getNotionHelp}. */
 export type HelpParams = { tool_name?: string };
 


### PR DESCRIPTION
## Summary

Adds `notion_upload_file`, a new tool that uploads a local binary file to Notion and attaches it as a downloadable file block on a page. Fills the gap where agents generating HTML, PDF, or image files had no way to make them accessible in Notion.

### How it works

Three-step Notion File Upload API flow:

1. `fileUploads.create()` — reserve an upload slot (single-part mode)
2. `fileUploads.send()` — stream the binary via `fs.createReadStream`
3. `blocks.children.append()` — attach an `uploaded_file` block to the target page

### Tool schema

```
notion_upload_file({
  file_path: string,       // local path to the file
  page_id: string,         // target Notion page
  display_name?: string,   // override filename in Notion
  content_type?: string,   // MIME type, auto-detected from extension
})
```

### MIME detection

Extension-based lookup for 22 common types (.pdf, .html, .png, .jpg, .gif, .svg, .webp, .mp4, .mp3, .ogg, .wav, .zip, .json, .csv, .txt, .md, .doc, .docx, .xls, .xlsx, .htm) with `application/octet-stream` fallback. No new dependencies.

### Changes

- `src/tools/upload.ts` — core implementation
- `src/types.ts` — `UploadParams`, `FileUploadsApi` types
- `src/audit.ts` — `upload_file` operation type
- `src/tools/help.ts` — documentation entry
- `src/index.ts` — tool registration with audit wrapper

### Validation

- `tsc --noEmit` passes
- `biome check` clean

Closes #18

## Summary by Sourcery

Add a new tool for uploading local files to Notion and attaching them to pages as file blocks.

New Features:
- Introduce the notion_upload_file tool to upload local binary files and attach them as file blocks on Notion pages.

Enhancements:
- Expose the uploadNotionFile helper and its parameters in the public plugin API, including MIME type inference for common file extensions.
- Extend auditing to track file upload operations and add corresponding help documentation for the new tool.