### PR TITLE
feat: add include_all_blocks to notion_comment_list for inline comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -362,11 +362,18 @@ export default definePluginEntry({
     api.registerTool((ctx) => ({
       name: 'notion_comment_list',
       label: 'Notion Comment List',
-      description: 'List comments attached to a Notion page.',
+      description:
+        'List comments on a Notion page. Set include_all_blocks to true to also retrieve inline comments on child blocks (paragraphs, headings, etc.), not just page-level comments.',
       parameters: Type.Object({
         page_id: Type.String({
           description: 'The UUID of the Notion page whose comments to list.',
         }),
+        include_all_blocks: Type.Optional(
+          Type.Boolean({
+            description:
+              'When true, also fetches inline comments from every child block on the page. Defaults to false (page-level comments only).',
+          })
+        ),
       }),
       async execute(_id, params) {
         return withAudit({
@@ -375,9 +382,48 @@ export default definePluginEntry({
           agentId: ctx.agentId,
           targetPageId: params.page_id,
           fn: async () => {
-            return asJsonContent(
-              (await getClient(ctx.agentId).comments.list({ block_id: params.page_id })).results
-            );
+            const notion = getClient(ctx.agentId);
+
+            // Page-level comments (always fetched).
+            const pageComments = (await notion.comments.list({ block_id: params.page_id })).results;
+
+            if (!params.include_all_blocks) {
+              return asJsonContent(pageComments);
+            }
+
+            // Inline comments live on individual child blocks, not the page
+            // itself. Walk all block children and collect their comments.
+            const allComments = [...pageComments];
+            const seenIds = new Set(pageComments.map((c: { id: string }) => c.id));
+
+            let startCursor: string | undefined;
+            do {
+              const blocks = await notion.blocks.children.list({
+                block_id: params.page_id,
+                start_cursor: startCursor,
+                page_size: DEFAULT_PAGE_SIZE,
+              });
+
+              for (const block of blocks.results) {
+                const b = block as { id: string };
+                try {
+                  const blockComments = (await notion.comments.list({ block_id: b.id })).results;
+                  for (const comment of blockComments) {
+                    const c = comment as { id: string };
+                    if (!seenIds.has(c.id)) {
+                      seenIds.add(c.id);
+                      allComments.push(comment);
+                    }
+                  }
+                } catch {
+                  // Some block types don't support comments — skip silently.
+                }
+              }
+
+              startCursor = blocks.next_cursor ?? undefined;
+            } while (startCursor);
+
+            return asJsonContent(allComments);
           },
         });
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { logOperation, setAuditContext } from './audit.js';
 import { getClient, getMarkdownPagesApi } from './client.js';
 import { DEFAULT_PAGE_SIZE } from './constants.js';
 import { asJsonContent, asTextContent, wrapPageResponse } from './format.js';
-import { findTitlePropertyName } from './helpers.js';
+import { findTitlePropertyName, isRecord } from './helpers.js';
 import { runNotionDoctor } from './tools/doctor.js';
 import { getNotionFileTree } from './tools/file-tree.js';
 import { getNotionHelp } from './tools/help.js';
@@ -392,36 +392,55 @@ export default definePluginEntry({
             }
 
             // Inline comments live on individual child blocks, not the page
-            // itself. Walk all block children and collect their comments.
+            // itself. Recursively walk the block tree to catch comments on
+            // nested blocks (inside toggles, columns, etc.), not just
+            // first-level children.
             const allComments = [...pageComments];
             const seenIds = new Set(pageComments.map((c: { id: string }) => c.id));
 
-            let startCursor: string | undefined;
-            do {
-              const blocks = await notion.blocks.children.list({
-                block_id: params.page_id,
-                start_cursor: startCursor,
-                page_size: DEFAULT_PAGE_SIZE,
-              });
+            const collectBlockComments = async (parentId: string, depth: number) => {
+              // Cap recursion to avoid runaway traversal on deeply nested pages.
+              if (depth > 5) return;
 
-              for (const block of blocks.results) {
-                const b = block as { id: string };
-                try {
-                  const blockComments = (await notion.comments.list({ block_id: b.id })).results;
-                  for (const comment of blockComments) {
-                    const c = comment as { id: string };
-                    if (!seenIds.has(c.id)) {
-                      seenIds.add(c.id);
-                      allComments.push(comment);
+              let startCursor: string | undefined;
+              do {
+                const blocks = await notion.blocks.children.list({
+                  block_id: parentId,
+                  start_cursor: startCursor,
+                  page_size: DEFAULT_PAGE_SIZE,
+                });
+
+                for (const block of blocks.results) {
+                  const b = block as { id: string; has_children?: boolean };
+                  try {
+                    const blockComments = (await notion.comments.list({ block_id: b.id })).results;
+                    for (const comment of blockComments) {
+                      const c = comment as { id: string };
+                      if (!seenIds.has(c.id)) {
+                        seenIds.add(c.id);
+                        allComments.push(comment);
+                      }
                     }
+                  } catch (error) {
+                    // Only swallow "not supported" errors. Re-surface network,
+                    // auth, and rate-limit failures so partial results are visible.
+                    if (isRecord(error) && typeof error.code === 'string') {
+                      const code = error.code;
+                      if (code === 'validation_error' || code === 'object_not_found') continue;
+                    }
+                    throw error;
                   }
-                } catch {
-                  // Some block types don't support comments — skip silently.
+                  // Recurse into blocks that have children (toggles, columns, etc.).
+                  if (b.has_children) {
+                    await collectBlockComments(b.id, depth + 1);
+                  }
                 }
-              }
 
-              startCursor = blocks.next_cursor ?? undefined;
-            } while (startCursor);
+                startCursor = blocks.next_cursor ?? undefined;
+              } while (startCursor);
+            };
+
+            await collectBlockComments(params.page_id, 0);
 
             return asJsonContent(allComments);
           },

--- a/src/tools/help.ts
+++ b/src/tools/help.ts
@@ -60,9 +60,10 @@ export const TOOL_DOCS: ToolDoc[] = [
   },
   {
     name: 'notion_comment_list',
-    description: 'List comments for a page.',
-    parameters: ['page_id: string'],
-    example: '{"page_id":"<page-id>"}',
+    description:
+      'List comments for a page. Set include_all_blocks to true to include inline comments on child blocks.',
+    parameters: ['page_id: string', 'include_all_blocks?: boolean (default false)'],
+    example: '{"page_id":"<page-id>","include_all_blocks":true}',
   },
   {
     name: 'notion_query',


### PR DESCRIPTION
## Summary

`notion_comment_list` only returned page-level comments. Inline comments (discussions anchored to specific blocks like paragraphs and headings) were invisible because they live on child block IDs, not the page ID.

### Fix

New optional parameter `include_all_blocks` (default `false`):

- **false**: existing behavior, page-level comments only
- **true**: enumerates all child blocks via `blocks.children.list`, queries `comments.list` for each, and deduplicates by comment ID

### Usage

```json
{"page_id": "<page-id>", "include_all_blocks": true}
```

### Notes

- Backward-compatible: default behavior unchanged
- Block types that don't support comments are silently skipped
- Comments are deduplicated so page-level and block-level don't overlap

Closes #10

## Summary by Sourcery

Extend the Notion comment listing tool to optionally include inline comments on all child blocks of a page while keeping existing behavior by default.

New Features:
- Add an optional include_all_blocks parameter to notion_comment_list to fetch comments from child blocks in addition to page-level comments.

Enhancements:
- Improve tool and help documentation for notion_comment_list to describe inline comment support, new parameter, and example usage.